### PR TITLE
fix: compiler/lint rules to work with Web

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     ],
     rules: {
         "@typescript-eslint/explicit-function-return-type": "off",
+        "react/prop-types": "off",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
     },

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -5,6 +5,7 @@
         "lib": ["es2018", "dom", "dom.iterable"],
         "allowJs": true,
         "esModuleInterop": true,
+        "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
         "isolatedModules": true,
         "jsx": "react",


### PR DESCRIPTION
A few minor adjustments to make writing non-trivial components in the SDK possible. Disabling "strictNullChecks" is temporary until we can fix things up in Web.