### PR TITLE
fix: Add debug url param to webviewer loading url

### DIFF
--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -26,7 +26,7 @@
         </style>
     </head>
     <body>
-        <iframe src="/viewer/index.html#no-bootstrap" onload="iframeLoaded(event)"></iframe>
+        <iframe src="/viewer/index.html?debug=true#no-bootstrap" onload="iframeLoaded(event)"></iframe>
         <script>
             function iframeLoaded(event) {
                 const webpackFiles = <%= JSON.stringify(htmlWebpackPlugin.files) %>;


### PR DESCRIPTION
Load the viewer in debug mode, for both enhanced logging and loading of development libraries for dependencies like react.