### PR TITLE
feat: forward locale url param to Web

### DIFF
--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -64,11 +64,7 @@
                         }
 
                         const urlParams = new URLSearchParams(window.location.search);
-                        const locale = urlParams.get("locale");
-
-                        if (locale) {
-                            options.locale = locale;
-                        }
+                        options.locale = urlParams.get("locale");
 
                         webViewer.bootstrap(options);
                     });

--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -26,7 +26,10 @@
         </style>
     </head>
     <body>
-        <iframe src="/viewer/index.html?debug=true#no-bootstrap" onload="iframeLoaded(event)"></iframe>
+        <iframe
+            src="/viewer/index.html?debug=true#no-bootstrap"
+            onload="iframeLoaded(event)"
+        ></iframe>
         <script>
             function iframeLoaded(event) {
                 const webpackFiles = <%= JSON.stringify(htmlWebpackPlugin.files) %>;
@@ -58,6 +61,13 @@
                             appConfig: getAbsoluteUrl("app.json"),
                             layout: getAbsoluteUrl("layout.xml"),
                             libraries: libs.map(lib => lib.default),
+                        }
+
+                        const urlParams = new URLSearchParams(window.location.search);
+                        const locale = urlParams.get("locale");
+
+                        if (locale) {
+                            options.locale = locale;
                         }
 
                         webViewer.bootstrap(options);


### PR DESCRIPTION
Allows forwarding of the `locale` URL param to Web to test the rendering of different locales. 

For example to test German, change the url from:

```
http://localhost:3000
```

to:

```
http://localhost:3000/?locale=de
```