### PR TITLE
fix: proxy query params and postMessage events

### DIFF
--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -26,10 +26,6 @@
         </style>
     </head>
     <body>
-        <iframe
-            src="/viewer/index.html?debug=true#no-bootstrap"
-            onload="iframeLoaded(event)"
-        ></iframe>
         <script>
             function iframeLoaded(event) {
                 const webpackFiles = <%= JSON.stringify(htmlWebpackPlugin.files) %>;
@@ -40,6 +36,32 @@
                 if (!iframeWindow.require) {
                     console.error("Geocortex Web frame failed to load");
                     return;
+                }
+
+                // Proxy postMessage events when the SDK preview is embedded in another page.
+                // This is for development purposes only, and is NOT recommended for production
+                // for security reasons.
+                // See https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage.
+                if (window.parent) {
+                    const handlePostMessage = (event) => {
+                        // Event came from parent. Forward to viewer frame.
+                        if (event.source === window.parent) {
+                            iframeWindow.postMessage(event.data, "*");
+                        }
+                        // Event came from viewer. Forward to parent.
+                        else if (event.source === iframeWindow) {
+                            window.parent.postMessage(event.data, "*")
+                        }
+                    }
+
+                    window.addEventListener("message", handlePostMessage);
+
+                    // If we don't remove the event listener, we can end up with multiple
+                    // listeners attached when the iframe is reloaded, such as when
+                    // triggered via webpack hot module reload.
+                    iframeWindow.addEventListener("unload", () => {
+                        window.removeEventListener("message", handlePostMessage)
+                    });
                 }
 
                 iframeWindow.require(["require", "gwv"], function(require, webViewer) {
@@ -57,37 +79,46 @@
                     ], (
                         ...libs
                     ) => {
-                        const options = {
+                        webViewer.bootstrap({
                             appConfig: getAbsoluteUrl("app.json"),
                             layout: getAbsoluteUrl("layout.xml"),
                             libraries: libs.map(lib => lib.default),
-                        }
-
-                        const urlParams = new URLSearchParams(window.location.search);
-                        options.locale = urlParams.get("locale");
-
-                        webViewer.bootstrap(options);
+                        });
                     });
                 });
             }
 
-            (function() {
-                const iframe = document.querySelector("iframe");
-                const iframeDocument = iframe.contentDocument;
-                const iframeWindow = iframe.contentWindow;
+            function injectIframe() {
+                const iframe = document.createElement("iframe");
 
-                const hookReactDevTools = () => {
-                    // Hook in React Dev Tools support
-                    iframeWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__ =
-                        window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-                };
-
-                if (iframeDocument.readyState === "loading") {
-                    iframe.contentDocument.addEventListener("DOMContentLoaded", hookReactDevTools);
-                } else {
-                    hookReactDevTools();
+                const selfUrl = new URL(location);
+                const iframeSrc = new URL("/viewer/index.html?debug=true#no-bootstrap", selfUrl.origin);
+                // Forward all query params to viewer
+                for (const [key, value] of selfUrl.searchParams) {
+                    iframeSrc.searchParams.set(key, value);
                 }
-            })();
+                iframe.src = iframeSrc;
+
+                iframe.addEventListener("load", iframeLoaded);
+                document.body.appendChild(iframe);
+
+                iframe.contentWindow.addEventListener("DOMContentLoaded", () => {
+                    // Hook in React Dev Tools support
+                    iframe.contentWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__ =
+                            window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+                });
+
+                // Instead of letting the frame reload via HMR, remove and
+                // inject a new iframe. This allows us to once again inject the
+                // react devtools hook so the devtools continue to work after
+                // reloading the frame.
+                iframe.contentWindow.addEventListener("beforeunload", () => {
+                    document.body.removeChild(iframe);
+                    injectIframe();
+                });
+            }
+
+            injectIframe();
         </script>
     </body>
 </html>

--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -39,7 +39,7 @@
                 }
 
                 // Proxy postMessage events when the SDK preview is embedded in another page.
-                // This is for development purposes only, and is NOT recommended for production
+                // This is for development purposes only. Using "*" is NOT recommended for production
                 // for security reasons.
                 // See https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage.
                 if (window.parent) {


### PR DESCRIPTION
This adds logic to proxy postMessage events in both directions through our wrapper `iframe`. We're also proxying URL params through as well to enable things like `isEmbedded=true`, while simplifying our existing `locale` support.

This also fixes an issue where the React devtools hook would break after a reload of the viewer triggered via webpack.