### PR TITLE
fix: Update sample to use new command registration in 5.7

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 -   Disable code splitting (if possible) and call it out in readme. Validate behavior of `import()`
 -   Flesh out README.md in template with additional info and validate hyperlinks
 -   Develop against an existing app use case - instead of using app/layout in template?
--   Switch to new `@vertigis/web` package when available
 -   Use Case that needs investigation (may run into issues):
     -   Develop library, upload to app via designer and push to prod
     -   Go to make changes to same library and test in designer (this functionality doesn't yet exist)

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     },
     "devDependencies": {
         "@types/node": "^12.12.31",
+        "@vertigis/web": "5.7.0-beta.96",
         "cross-env": "^7.0.2",
         "husky": "^4.2.3",
         "prettier": "^2.0.2",

--- a/template/package.json
+++ b/template/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {},
     "devDependencies": {
+        "@vertigis/web": "5.7.0-beta.96",
         "typescript": "^3.8.3"
     }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -12,7 +12,6 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@vertigis/web": "5.7.0-beta.96",
         "typescript": "^3.8.3"
     }
 }

--- a/template/src/components/PointsOfInterest/PointsOfInterestModel.ts
+++ b/template/src/components/PointsOfInterest/PointsOfInterestModel.ts
@@ -6,7 +6,7 @@ import {
 } from "@vertigis/web/models";
 import { LocationMarkerEvent } from "@vertigis/viewer-spec/messaging/registry/location-marker";
 import { toColor } from "@vertigis/web/branding";
-import { GeometryResults } from "@vertigis/web/messaging";
+import { command, HasGeometry } from "@vertigis/web/messaging";
 import { MapExtension } from "@vertigis/arcgis-extensions/mapping/MapExtension";
 import { ChangeEvent } from "@vertigis/arcgis-extensions/support/esri";
 import Collection from "esri/core/Collection";
@@ -45,7 +45,8 @@ export default class PointsOfInterestModel extends ComponentModelBase {
     /**
      * Creates a new point of interest at the specified location.
      */
-    async createNew(location: GeometryResults): Promise<void> {
+    @command("points-of-interest.create")
+    async createNew(location: HasGeometry): Promise<void> {
         const id = this._nextId++;
 
         // Prompt the user for a name using the built-in ui.prompt operation.
@@ -84,15 +85,9 @@ export default class PointsOfInterestModel extends ComponentModelBase {
         // override a method.
         await super._onInitialize();
 
-        // Registration handles for event and command handlers should be saved
-        // and cleaned up when no longer needed.
+        // Registration handles for event handlers should be saved and cleaned
+        // up when no longer needed.
         this._handles.push(
-            // Register an implementation for our custom command. The map's
-            // onClick action is wired up to run this command in the sample
-            // app.json.
-            this.messages
-                .command<GeometryResults>("points-of-interest.create")
-                .register((location) => this.createNew(location)),
             this.messages.events.locationMarker.updated.subscribe(this._onMarkerUpdated),
             this.pointsOfInterest.on("change", this._onPointOfInterestsChange)
         );

--- a/template/src/index.ts
+++ b/template/src/index.ts
@@ -1,6 +1,5 @@
 import PointsOfInterest, { PointsOfInterestModel } from "./components/PointsOfInterest";
 import { LibraryRegistry } from "@vertigis/web/config";
-import { ComponentType } from "react";
 
 const LAYOUT_NAMESPACE = "custom.foo";
 
@@ -8,7 +7,7 @@ export default function (registry: LibraryRegistry) {
     registry.registerComponent({
         name: "points-of-interest",
         namespace: LAYOUT_NAMESPACE,
-        getComponentType: () => PointsOfInterest as ComponentType,
+        getComponentType: () => PointsOfInterest,
         itemType: "points-of-interest-model",
         title: "Points of Interest",
     });
@@ -16,5 +15,8 @@ export default function (registry: LibraryRegistry) {
         getModel: (config) => new PointsOfInterestModel(config),
         itemType: "points-of-interest-model",
     });
-    registry.registerCommand("points-of-interest.create");
+    registry.registerCommand({
+        name: "points-of-interest.create",
+        itemType: "points-of-interest-model",
+    });
 }


### PR DESCRIPTION
This fixes the SDK sample to use the new command registration pattern recently introduced in 5.7.

I also temporarily have both the SDK and the template pointing at a beta version of @vertigis/web just to get things working again. We'll need to update it to the final version once released. To test, make sure to set the `VIEWER_URL` environment variable to `VIEWER_URL=https://apps-staging.geocortex.com/webviewer`.