### PR TITLE
fix: webpack loader resolution

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -77,13 +77,13 @@ module.exports = {
                         sideEffects: true,
                         use: [
                             {
-                                loader: "style-loader",
+                                loader: require.resolve("style-loader"),
                                 options: {
                                     esModule: true,
                                 },
                             },
                             {
-                                loader: "css-loader",
+                                loader: require.resolve("css-loader"),
                                 options: {
                                     esModule: true,
                                     // How many loaders before "css-loader" should be applied to "@import"ed resources
@@ -93,7 +93,7 @@ module.exports = {
                             {
                                 // Adds vendor prefixing based on your specified browser support in
                                 // package.json
-                                loader: "postcss-loader",
+                                loader: require.resolve("postcss-loader"),
                                 options: {
                                     ident: "postcss",
                                     plugins: () =>


### PR DESCRIPTION
Fixes webpack loader resolution when multiple versions of a given loader exist in the project. This ensures that the loader is resolved relative to the SDK, so the version referenced by the SDK is used instead.