### PR TITLE
test: add smoke tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
                   node-version: 12.x
 
             - run: npm install
-              with:
+              env:
                   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
 
             - name: Release 🚀

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,6 +53,8 @@ jobs:
                   node-version: 12.x
 
             - run: npm install
+              with:
+                  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
 
             - name: Release 🚀
               env:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "printWidth": 100,
+    "printWidth": 80,
     "tabWidth": 4,
     "trailingComma": "es5"
 }

--- a/bin/vertigis-web-sdk.js
+++ b/bin/vertigis-web-sdk.js
@@ -10,7 +10,7 @@ const scriptIndex = args.findIndex(
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 
 if (["build", "create", "start"].includes(script)) {
-    require(require.resolve(`../scripts/${script}`));
+    require(`../scripts/${script}`);
 } else {
     console.log('Unknown script "' + script + '".');
 }

--- a/bin/vertigis-web-sdk.js
+++ b/bin/vertigis-web-sdk.js
@@ -2,38 +2,15 @@
 // @ts-check
 "use strict";
 
-const spawn = require("cross-spawn");
 const args = process.argv.slice(2);
 
-const scriptIndex = args.findIndex(x => x === "build" || x === "create" || x === "start");
+const scriptIndex = args.findIndex(
+    (x) => x === "build" || x === "create" || x === "start"
+);
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
-const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 
 if (["build", "create", "start"].includes(script)) {
-    const result = spawn.sync(
-        "node",
-        nodeArgs
-            .concat(require.resolve("../scripts/" + script))
-            .concat(args.slice(scriptIndex + 1)),
-        { stdio: "inherit" }
-    );
-    if (result.signal) {
-        if (result.signal === "SIGKILL") {
-            console.log(
-                "The build failed because the process exited too early. " +
-                    "This probably means the system ran out of memory or someone called " +
-                    "`kill -9` on the process."
-            );
-        } else if (result.signal === "SIGTERM") {
-            console.log(
-                "The build failed because the process exited too early. " +
-                    "Someone might have called `kill` or `killall`, or the system could " +
-                    "be shutting down."
-            );
-        }
-        process.exit(1);
-    }
-    process.exit(result.status);
+    require(require.resolve(`../scripts/${script}`));
 } else {
     console.log('Unknown script "' + script + '".');
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -29,7 +29,13 @@ module.exports = {
         extensions: paths.moduleFileExtensions,
     },
     entry: paths.projEntry,
-    externals: [/^dojo\/.+$/, /^esri\/.+$/, /^@vertigis\/.+$/, "react", "react-dom"],
+    externals: [
+        /^dojo\/.+$/,
+        /^esri\/.+$/,
+        /^@vertigis\/.+$/,
+        "react",
+        "react-dom",
+    ],
     output: {
         // Technically this shouldn't be needed as we restrict the library to
         // one chunk, but we set this here just to be extra safe against
@@ -106,7 +112,8 @@ module.exports = {
                                                     "last 2 safari versions",
                                                 ],
                                             }),
-                                            isEnvProduction && require("cssnano")(),
+                                            isEnvProduction &&
+                                                require("cssnano")(),
                                         ].filter(Boolean),
                                 },
                             },

--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -89,6 +89,7 @@
 
             function injectIframe() {
                 const iframe = document.createElement("iframe");
+                iframe.name = "viewer";
 
                 const selfUrl = new URL(location);
                 const iframeSrc = new URL("/viewer/index.html?debug=true#no-bootstrap", selfUrl.origin);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "build": "cd template && npm link \"../\" --no-package-lock && npm run build",
         "create": "cross-env SDK_LOCAL_DEV=true node bin/vertigis-web-sdk.js create",
         "start": "cd template && npm link \"../\" --no-package-lock && npm run start",
-        "test": "echo \"No tests yet. All clear!\""
+        "test": "node ./test/index.js"
     },
     "dependencies": {
         "@typescript-eslint/eslint-plugin": "^3.1.0",
@@ -34,7 +34,6 @@
         "autoprefixer": "^9.8.0",
         "chalk": "^4.0.0",
         "clean-webpack-plugin": "^3.0.0",
-        "cross-spawn": "^7.0.3",
         "css-loader": "^3.5.3",
         "cssnano": "^4.1.10",
         "eslint": "^7.2.0",
@@ -57,7 +56,10 @@
         "@vertigis/web": "5.7.0",
         "conventional-changelog-conventionalcommits": "^4.3.0",
         "cross-env": "^7.0.2",
+        "execa": "^4.0.2",
         "husky": "^4.2.5",
+        "p-retry": "^4.2.0",
+        "playwright-chromium": "^1.1.1",
         "prettier": "^2.0.5",
         "pretty-quick": "^2.0.1",
         "react": "^16.13.1",

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -8,7 +8,7 @@ const fs = require("fs-extra");
 const path = require("path");
 
 const rootDir = path.join(__dirname, "..");
-const directoryName = process.argv[2];
+const directoryName = process.argv[3];
 const directoryPath = path.resolve(directoryName);
 
 const checkSpawnSyncResult = (syncResult) => {
@@ -21,7 +21,9 @@ const copyTemplate = (rootPath) => {
     if (fs.existsSync(rootPath) && fs.readdirSync(rootPath).length > 0) {
         console.error(
             chalk.red(
-                `Cannot create new project at ${chalk.green(rootPath)} as it already exists.\n`
+                `Cannot create new project at ${chalk.green(
+                    rootPath
+                )} as it already exists.\n`
             )
         );
         process.exit(1);
@@ -35,7 +37,10 @@ const copyTemplate = (rootPath) => {
     });
     // Rename gitignore after the fact to prevent npm from renaming it to .npmignore
     // See: https://github.com/npm/npm/issues/1862
-    fs.moveSync(path.join(rootPath, "gitignore"), path.join(rootPath, ".gitignore"));
+    fs.moveSync(
+        path.join(rootPath, "gitignore"),
+        path.join(rootPath, ".gitignore")
+    );
 };
 
 const updateTemplateContent = (rootPath) => {
@@ -94,7 +99,11 @@ const gitInit = (rootPath) => {
 };
 
 const printSuccess = () => {
-    console.log(`${chalk.green("Success!")} Created ${directoryName} at ${directoryPath}\n`);
+    console.log(
+        `${chalk.green(
+            "Success!"
+        )} Created ${directoryName} at ${directoryPath}\n`
+    );
     console.log("Inside that directory, you can run several commands:\n");
     console.log(chalk.cyan(`  npm start`));
     console.log("    Starts the development server.\n");

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -22,7 +22,8 @@ const webpackConfig = require("../config/webpack.config");
 const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
 
-const viewerTarget = process.env.VIEWER_URL || "https://apps.geocortex.com/webviewer";
+const viewerTarget =
+    process.env.VIEWER_URL || "https://apps.geocortex.com/webviewer";
 const port = process.env.PORT || 3000;
 
 const compiler = webpack(webpackConfig);
@@ -37,7 +38,7 @@ const serverConfig = {
     // Allow binding to any host (localhost, jdoe-pc.latitudegeo.com, etc).
     host: "0.0.0.0",
     hot: true,
-    open: true,
+    open: process.env.OPEN_BROWSER !== "false",
     port,
     proxy: {
         "/viewer": {
@@ -61,7 +62,8 @@ const serverConfig = {
 const devServer = new WebpackDevServer(compiler, serverConfig);
 devServer.listen(serverConfig.port, serverConfig.host, (err) => {
     if (err) {
-        throw err;
+        console.error(err);
+        process.exit(1);
     }
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,121 @@
+// @ts-check
+"use strict";
+
+process.env.OPEN_BROWSER = "false";
+process.env.SDK_LOCAL_DEV = "true";
+
+const execa = require("execa");
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { chromium } = require("playwright-chromium");
+const pRetry = require("p-retry");
+
+const rootDir = path.join(__dirname, "..");
+const testLibProjPath = path.join(rootDir, "test-lib");
+
+/** @type {execa.ExecaChildProcess<string>} */
+let subprocess;
+
+/**
+ * @param {Array<string>} args
+ * @param {execa.Options<string>} [opts]
+ */
+function runNpmScript(args, opts) {
+    console.log(`Executing CLI script: ${args.join(" ")}`);
+    const scriptProcess = execa(
+        "node",
+        [path.join(rootDir, "bin/vertigis-web-sdk.js"), ...args],
+        opts
+    );
+
+    // pipe process output to current process output so it is visible in the
+    // console, but still allows us to examine the subprocess stdout/stderr
+    // variables.
+
+    scriptProcess.stdout.pipe(process.stdout);
+    scriptProcess.stderr.pipe(process.stderr);
+
+    return scriptProcess;
+}
+
+function killSubprocess() {
+    if (subprocess && !subprocess.killed) {
+        subprocess.kill();
+    }
+}
+
+async function testCreateProject() {
+    // First try creating the project.
+    subprocess = runNpmScript(["create", "test-lib"]);
+    await subprocess;
+
+    // Try to create same named project again.
+    subprocess = runNpmScript(["create", "test-lib"], { reject: false });
+    const processResult = await subprocess;
+    assert.strictEqual(
+        processResult.stderr.includes(
+            `Cannot create new project at ${testLibProjPath} as it already exists`
+        ),
+        true,
+        "Failed to detect existing directory"
+    );
+}
+
+// We assume the project was successfully created to run the following tests.
+async function testBuildProject() {
+    subprocess = runNpmScript(["build"], { cwd: testLibProjPath });
+    await subprocess;
+    assert.strictEqual(
+        fs.existsSync(path.join(testLibProjPath, "build/main.js")),
+        true,
+        "build/main.js is missing"
+    );
+}
+
+async function testStartProject() {
+    subprocess = runNpmScript(["start"], { cwd: testLibProjPath });
+
+    const browser = await chromium.launch();
+
+    try {
+        const page = await browser.newPage();
+        await pRetry(() => page.goto("http://localhost:3000"), {
+            maxRetryTime: 10000,
+        });
+        const frame = page.frame("viewer");
+        await frame.waitForSelector("text=Points of Interest");
+    } catch (e) {
+        await browser.close();
+        throw e;
+    }
+
+    await browser.close();
+    killSubprocess();
+}
+
+function rmdir(path) {
+    fs.rmdirSync(path, { recursive: true });
+}
+
+function cleanup() {
+    console.log("Cleaning up...");
+    killSubprocess();
+    rmdir(testLibProjPath);
+    console.log("Done cleaning.");
+}
+
+(async () => {
+    try {
+        await testCreateProject();
+        await testBuildProject();
+        await testStartProject();
+        console.log("All tests passed!");
+        cleanup();
+    } catch (error) {
+        console.error("Test failed.");
+        console.error(error);
+        cleanup();
+        process.exit(1);
+    }
+})();

--- a/test/index.js
+++ b/test/index.js
@@ -29,10 +29,9 @@ function runNpmScript(args, opts) {
         opts
     );
 
-    // pipe process output to current process output so it is visible in the
+    // Pipe process output to current process output so it is visible in the
     // console, but still allows us to examine the subprocess stdout/stderr
     // variables.
-
     scriptProcess.stdout.pipe(process.stdout);
     scriptProcess.stderr.pipe(process.stderr);
 

--- a/test/index.js
+++ b/test/index.js
@@ -84,13 +84,10 @@ async function testStartProject() {
         });
         const frame = page.frame("viewer");
         await frame.waitForSelector("text=Points of Interest");
-    } catch (e) {
+    } finally {
         await browser.close();
-        throw e;
+        killSubprocess();
     }
-
-    await browser.close();
-    killSubprocess();
 }
 
 function rmdir(path) {


### PR DESCRIPTION
Adds a set of basic smoke tests to validate the core functionality works as expected. These will run as part of the CI build.

I changed the CLI to require the appropriate script module (`create`, `build`, ...) instead of spawning a new process. This fixed some issues with process cleanup when invoking the CLI via the tests. The `start` script specifically would remain running even after killing the spawned process that ran the CLI, which meant that webpack-dev-server continued to run after the test had finished in some circumstances.