### PR TITLE
fix: disable overly strict ESLint rules

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -32,6 +32,10 @@ module.exports = {
     ],
     rules: {
         "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
         "react/prop-types": "off",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",

--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -32,10 +32,11 @@ module.exports = {
     ],
     rules: {
         "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
         "react/prop-types": "off",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",


### PR DESCRIPTION
After enabling ESLint checking in the samples repo, I felt that these rules i've disabled here were too strict, and are likely to annoy developers.