### PR TITLE
feat: add OPEN_PAGE environment variable

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -31,7 +31,7 @@ const compiler = webpack(webpackConfig);
 const serverConfig = {
     after: function () {
         if (process.env.OPEN_BROWSER !== "false") {
-            open(`http://localhost:${port}`);
+            open(`http://localhost:${port}${process.env.OPEN_PAGE || ""}`);
         }
     },
     clientLogLevel: "silent",
@@ -72,8 +72,7 @@ const serverConfig = {
 const devServer = new WebpackDevServer(compiler, serverConfig);
 devServer.listen(serverConfig.port, serverConfig.host, (err) => {
     if (err) {
-        console.error(err);
-        process.exit(1);
+        throw err;
     }
 });
 


### PR DESCRIPTION
Adds a new `OPEN_PAGE` environment variable to control the default page that the browser opens to. This lets us support the [iframe example](https://github.com/geocortex/vertigis-web-samples/tree/92b4ba2c1b1e7483e3d322689e4615f28e2046ee/samples/iframe).