### PR TITLE
feat: add url-loader to webpack config

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -67,6 +67,15 @@ module.exports = {
                 // match the requirements. When no loader matches it will fall
                 // back to the "file" loader at the end of the loader list.
                 oneOf: [
+                    // Embeds assets smaller than the specified limit (Infinity
+                    // in our case) as data URLs.
+                    {
+                        test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
+                        loader: require.resolve("url-loader"),
+                        options: {
+                            esModule: true,
+                        },
+                    },
                     // Process application JS with Babel.
                     // The preset includes JSX, Flow, TypeScript, and some ESnext features.
                     {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "style-loader": "^1.2.1",
         "terser-webpack-plugin": "^3.0.6",
         "ts-loader": "^7.0.5",
+        "url-loader": "^4.1.0",
         "webpack": "^4.43.0",
         "webpack-dev-server": "^3.11.0"
     },


### PR DESCRIPTION
This adds [`url-loader`](https://github.com/webpack-contrib/url-loader) to our webpack config to support importing static assets such as images and fonts. These assets will be inlined as data URIs as we only support a single chunk to be emitted.

This makes us more compatible with 3rd party libraries, such as Mapillary that uses `url()` statements in their CSS to reference relative SVGs in their package.