### PR TITLE
feat: Adding a script for updating package.json dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Runs the project in development mode. Open [http://localhost:3000](http://localh
 
 The page will automatically reload if you make changes to the code. You will see build errors and warnings in the console.
 
+### `npm run upgrade`
+
+Upgrades the library's dependencies to point to the latest versions of VertiGIS Studio Web and the VertiGIS Studio Web SDK.
+
 ### `npm run build`
 
 Builds the library for production to the `build` folder. It optimizes the build for the best performance.

--- a/bin/vertigis-web-sdk.js
+++ b/bin/vertigis-web-sdk.js
@@ -5,12 +5,12 @@
 const args = process.argv.slice(2);
 
 const scriptIndex = args.findIndex(
-    (x) => x === "build" || x === "create" || x === "start"
+    (x) => x === "build" || x === "create" || x === "start" || x === "upgrade"
 );
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 
-if (["build", "create", "start"].includes(script)) {
+if (["build", "create", "start", "upgrade"].includes(script)) {
     require(`../scripts/${script}`);
 } else {
-    console.log('Unknown script "' + script + '".');
+    console.error('Unknown script "' + script + '".');
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "fork-ts-checker-webpack-plugin": "^5.2.0",
         "fs-extra": "^10.0.0",
         "html-webpack-plugin": "^4.5.0",
+        "node-fetch": "^2.6.7",
         "open": "^8.2.0",
         "postcss-loader": "^3.0.0",
         "style-loader": "^1.2.1",
@@ -64,7 +65,7 @@
         "prettier": "^2.3.1",
         "pretty-quick": "^3.1.0",
         "semantic-release": "^17.4.3",
-        "typescript": "^4.3.2"
+        "typescript": "^4.5.5"
     },
     "husky": {
         "hooks": {

--- a/scripts/upgrade.js
+++ b/scripts/upgrade.js
@@ -1,0 +1,62 @@
+"use strict";
+
+// This script will update the custom library to target the latest version of
+// VertiGIS Studio Web and the Web SDK.
+
+const fetch = require("node-fetch");
+const fs = require("fs");
+const spawn = require("cross-spawn");
+
+(async () => {
+    console.info("Determining latest versions of Web and Web SDK...");
+    let responses = await Promise.all([
+        fetch("https://registry.npmjs.com/@vertigis/web/"),
+        fetch("https://registry.npmjs.com/@vertigis/web-sdk/"),
+    ]);
+    const [webInfo, sdkInfo] = await Promise.all(
+        responses.map((r) => r.json())
+    );
+    const latestWeb = webInfo["dist-tags"]?.latest;
+    if (!latestWeb) {
+        throw new Error(
+            "Unable to determine the latest version VertiGIS Studio Web."
+        );
+    }
+    const latestSDK = sdkInfo["dist-tags"]?.latest;
+    if (!latestSDK) {
+        throw new Error(
+            "Unable to determine the latest version VertiGIS Studio Web SDK."
+        );
+    }
+
+    const projectPackage = JSON.parse(
+        await fs.promises.readFile("package.json", "utf8")
+    );
+
+    // Update Web and SDK to latest versions.
+    projectPackage.devDependencies["@vertigis/web"] = `^${latestWeb}`;
+    projectPackage.devDependencies["@vertigis/web-sdk"] = `^${latestSDK}`;
+
+    // Add or update all of Web's dependencies as dev dependencies of this
+    // project. Although this is not strictly necessary for the project to
+    // build, aspects of VS Code intellisense like auto imports will not
+    // work without this.
+    console.info("Determining Web dependencies...");
+    const response = await fetch(
+        `https://registry.npmjs.com/@vertigis/web/${latestWeb}`
+    );
+    const webPackage = await response.json();
+    for (const [dep, version] of Object.entries(webPackage.dependencies)) {
+        projectPackage.devDependencies[dep] = version;
+    }
+
+    console.info("Updating package.json...");
+    await fs.promises.writeFile(
+        "package.json",
+        JSON.stringify(projectPackage, undefined, 4),
+        "utf8"
+    );
+
+    console.info("Running npm install...");
+    spawn.sync("npm", ["install"]);
+})();

--- a/template/package.json
+++ b/template/package.json
@@ -7,10 +7,11 @@
     "author": "",
     "scripts": {
         "build": "vertigis-web-sdk build",
-        "start": "vertigis-web-sdk start"
+        "start": "vertigis-web-sdk start",
+        "upgrade": "vertigis-web-sdk upgrade"
     },
     "dependencies": {},
     "devDependencies": {
-        "typescript": "^4.3.2"
+        "typescript": "^4.5.5"
     }
 }


### PR DESCRIPTION
This PR adds a new script to the SDK: `npm run upgrade`. When run within the context of a custom library created by the SDK, it will automatically upgrade its package.json to point at the latest versions of Web and the Web SDK. It will also explicitly add/update any of Web's dependencies as direct dependencies of the project. Without this, VS Code autocomplete and intellisense don't work for things like arcgis-extensions or react.