### PR TITLE
feat: add PUBLIC_DIR environment variable

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -29,7 +29,7 @@ const resolveOwn = (relativePath) =>
 module.exports = {
     projBuild: resolveProj("build"),
     projEntry: resolveModule(resolveProj, "src/index"),
-    projPublicDir: resolveProj("app"),
+    projPublicDir: resolveProj(process.env.PUBLIC_DIR || "app"),
     projRoot: resolveProj("."),
     projSrc: resolveProj("src"),
     ownPath: resolveOwn("."),


### PR DESCRIPTION
Adds a `PUBLIC_DIR` environment variable that allows you to override the default "app" directory of the project. This supports use cases where a single project contains multiple apps.

To use this you might add something like this to your `package.json` (or use `cross-env`):
```
"start": "vertigis-web-sdk start",
"start:app2": "set PUBLIC_DIR=app2&& npm run start"
```