### PR TITLE
feat: add BUILD_ENTRY_POINT environment variable

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -28,7 +28,7 @@ const resolveOwn = (relativePath) =>
 
 module.exports = {
     projBuild: resolveProj("build"),
-    projEntry: resolveModule(resolveProj, "src/index"),
+    projEntry: resolveModule(resolveProj, process.env.BUILD_ENTRY_POINT || "src/index"),
     projPublicDir: resolveProj(process.env.PUBLIC_DIR || "app"),
     projRoot: resolveProj("."),
     projSrc: resolveProj("src"),


### PR DESCRIPTION
Adds a BUILD_ENTRY_POINT environment variable that allows you to override the default "src/index" file of the project. This supports use cases where a single project contains multiple apps for which separate builds should be created.

To use this you might add something like this to your package.json (or use cross-env):
```
"build": "vertigis-web-sdk build",
"build:app2": "set BUILD_ENTRY_POINT=src/index.app2&& npm run build"
```