### PR TITLE
fix: update template to be compatible with web 42

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             },
             "devDependencies": {
                 "@types/node": "~22.13.14",
-                "@vertigis/web": "^5.38.0",
+                "@vertigis/web": "^5.42.0",
                 "conventional-changelog-conventionalcommits": "7.0.2",
                 "cross-env": "7.0.3",
                 "eslint": "^9.37.0",
@@ -35,35 +35,71 @@
                 "npm": ">=8"
             }
         },
-        "node_modules/@arcgis/core": {
-            "version": "4.33.13",
-            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.33.13.tgz",
-            "integrity": "sha512-Ff9CPxw6DsDVtNQBeOehgtZukwA6UWbUmGtDpUxdauv9cRIJ3+ODznnL83+6Zybu3S10DM1eAAfcwd04LEhlcA==",
+        "node_modules/@amcharts/amcharts5": {
+            "version": "5.15.6",
+            "resolved": "https://registry.npmjs.org/@amcharts/amcharts5/-/amcharts5-5.15.6.tgz",
+            "integrity": "sha512-6gVWngHgkMN+v6dJhZ4XJE3fcHjvD5hyjgyNnfvVE1H0ukmHpfFmhI7cCX0cgy0NRyZc4fwgxDMZsiNA7yYKjA==",
             "dev": true,
-            "license": "SEE LICENSE IN copyright.txt",
-            "peer": true,
+            "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
-                "@esri/arcgis-html-sanitizer": "~4.1.0",
-                "@esri/calcite-components": "^3.2.1",
-                "@vaadin/grid": "~24.7.6",
-                "@zip.js/zip.js": "~2.7.62",
-                "luxon": "~3.6.1",
-                "marked": "~15.0.12"
+                "@types/d3": "^7.0.0",
+                "@types/d3-chord": "^3.0.0",
+                "@types/d3-hierarchy": "3.1.1",
+                "@types/d3-sankey": "^0.11.1",
+                "@types/d3-shape": "^3.0.0",
+                "@types/geojson": "^7946.0.8",
+                "@types/polylabel": "^1.0.5",
+                "@types/svg-arc-to-cubic-bezier": "^3.2.0",
+                "d3": "^7.0.0",
+                "d3-chord": "^3.0.0",
+                "d3-force": "^3.0.0",
+                "d3-geo": "^3.0.0",
+                "d3-hierarchy": "^3.0.0",
+                "d3-sankey": "^0.12.3",
+                "d3-selection": "^3.0.0",
+                "d3-shape": "^3.0.0",
+                "d3-transition": "^3.0.0",
+                "d3-voronoi-treemap": "^1.1.2",
+                "flatpickr": "^4.6.13",
+                "markerjs2": "^2.29.4",
+                "pdfmake": "^0.2.2",
+                "polylabel": "^1.1.0",
+                "seedrandom": "^3.0.5",
+                "svg-arc-to-cubic-bezier": "^3.2.0",
+                "tslib": "^2.2.0"
             }
         },
-        "node_modules/@arcgis/lumina": {
-            "version": "4.34.0",
-            "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.34.0.tgz",
-            "integrity": "sha512-5YE4uFHKIqgwMbk2kQhw1fOGrzcXsUGFcgCBrWblu5v8SQ/gX+jL+dPnAgbFvhW9VKtGwmU3RE3MHXWNbmFQiw==",
+        "node_modules/@arcgis/core": {
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-5.0.12.tgz",
+            "integrity": "sha512-l+/UgeSIBl8SJshGtqMpAI7DlVfG9mIzDim+/7qbRm8L+yAkQmJBH1ifHoGNFDY0/ciDoxy5lriXZft7AlsWhg==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@arcgis/toolkit": "~4.34.0",
+                "@amcharts/amcharts5": "~5.15.5",
+                "@arcgis/toolkit": "^5.0.0",
+                "@esri/arcgis-html-sanitizer": "~4.1.0",
+                "@esri/calcite-components": "^5.0.2",
+                "@vaadin/grid": "~25.0.3",
+                "@zip.js/zip.js": "~2.8.16",
+                "luxon": "~3.7.2",
+                "marked": "~17.0.3",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@arcgis/lumina": {
+            "version": "5.1.10",
+            "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-5.1.10.tgz",
+            "integrity": "sha512-lAsGvtxnMq2YYvANXICPxMDA0q/VHHH76a6Vb45YAjXRTiIk6EjwwJ7hy6I6J+y7apdGxo9J0CoxhLQsMpfVyQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@arcgis/toolkit": "~5.1.10",
                 "csstype": "^3.1.3",
                 "tslib": "^2.8.1"
             },
             "peerDependencies": {
-                "@lit/context": "^1.1.5",
+                "@lit/context": "^1.1.6",
                 "lit": "^3.3.0"
             },
             "peerDependenciesMeta": {
@@ -73,9 +109,9 @@
             }
         },
         "node_modules/@arcgis/toolkit": {
-            "version": "4.34.0",
-            "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-4.34.0.tgz",
-            "integrity": "sha512-uN+9TxxUGuY4ALpUOffEH9XJi1Fye6HXXmGddKimNo7NoFEKUBm9pGBUlcBKWkLKuZe+WwOMWWXL79sXOPsRTg==",
+            "version": "5.1.10",
+            "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-5.1.10.tgz",
+            "integrity": "sha512-pOxk9Tbj370+le/uC4VuLAFrNJO/Fop8nUmy47mVrdRKwbX5eTeaTiDV1Q2raIGCbvH1z+Po/Y18RLpVKcnCgQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -83,12 +119,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -97,14 +133,15 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-            "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.28.3",
-                "@babel/types": "^7.28.2",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -114,56 +151,60 @@
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/types": "^7.28.4"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -173,9 +214,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -183,33 +224,35 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/parser": "^7.27.2",
-                "@babel/types": "^7.27.1"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-            "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.3",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.4",
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -217,17 +260,41 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@base-ui/utils": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.9.tgz",
+            "integrity": "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2",
+                "@floating-ui/utils": "^0.2.11",
+                "reselect": "^5.1.1",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^17 || ^18 || ^19",
+                "react": "^17 || ^18 || ^19",
+                "react-dom": "^17 || ^18 || ^19"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@csstools/cascade-layer-name-parser": {
@@ -337,7 +404,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -360,7 +426,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1444,6 +1509,7 @@
             "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
@@ -1464,6 +1530,7 @@
             "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1495,6 +1562,7 @@
             "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0"
             }
@@ -1591,6 +1659,7 @@
             "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
@@ -1649,9 +1718,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -1659,9 +1728,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -1715,18 +1784,20 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1772,7 +1843,6 @@
             "integrity": "sha512-einEveDJ/k1180NOp78PB/4Hje9eBy3dyOGLLtLn6bSkizpUfCwuYBIXOA7Y3F/k/BsTQXgKqUVwQ0eiscWMdA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "xss": "1.0.13"
             },
@@ -1781,22 +1851,22 @@
             }
         },
         "node_modules/@esri/calcite-components": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-3.3.3.tgz",
-            "integrity": "sha512-tw+EfJ3pb+Odj71W6E9GUkm8rMbNxfW1KeiI8GgsKDzhr39hMKwY+zYYFFYuO0FONxWGvAB+B8yqB0NvH7WeHw==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-5.1.2.tgz",
+            "integrity": "sha512-KdCk68T+UzVeAMA+kHW5UZ8msedBAH10k1J9Vkhqc8DtpJ0L/j2rw0ve9pbq1sW+hAAbhnTj+0OyP3R5bp1dEg==",
             "dev": true,
             "license": "SEE LICENSE.md",
             "dependencies": {
-                "@arcgis/lumina": ">=4.34.0-next.158 <4.35.0",
-                "@arcgis/toolkit": ">=4.34.0-next.158 <4.35.0",
-                "@esri/calcite-ui-icons": "4.3.0",
+                "@arcgis/lumina": ">=5.1.0-next.96 <6.0.0",
+                "@arcgis/toolkit": ">=5.1.0-next.96 <6.0.0",
+                "@esri/calcite-ui-icons": "4.5.0",
                 "@floating-ui/dom": "^1.6.12",
                 "@floating-ui/utils": "^0.2.8",
                 "@types/sortablejs": "^1.15.8",
-                "color": "^5.0.0",
+                "color": "^5.0.3",
                 "composed-offset-position": "^0.0.6",
                 "es-toolkit": "^1.39.8",
-                "focus-trap": "^7.6.5",
+                "focus-trap": "^8.2.1",
                 "interactjs": "^1.10.27",
                 "lit": "^3.3.0",
                 "sortablejs": "^1.15.6",
@@ -1805,43 +1875,101 @@
             }
         },
         "node_modules/@esri/calcite-ui-icons": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.3.0.tgz",
-            "integrity": "sha512-iOOuRurpjFxFVw6+aXW2JpSkRBrdOpBcbdibfPOmSPqMd1aoHBtYmYXetKoH9vfrXoBiPyO2PkDnczhsu/N9IA==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.5.0.tgz",
+            "integrity": "sha512-MuXK8o5qefXXV/vdDucQUm8zno+9Q0KjadCX82gYX1VgHMLPp0x2+pbQzG3c0MDbRqkidhTqL/zwq/eVq282qg==",
             "dev": true,
             "license": "SEE LICENSE.md",
             "bin": {
                 "spriter": "bin/spriter.js"
             }
         },
-        "node_modules/@floating-ui/core": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-            "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+        "node_modules/@fingerprintjs/fingerprintjs": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs/-/fingerprintjs-3.4.2.tgz",
+            "integrity": "sha512-3Ncze6JsJpB7BpYhqIgvBpfvEX1jsEKrad5hQBpyRQxtoAp6hx3+R46zqfsuQG4D9egQZ+xftQ0u4LPFMB7Wmg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.10"
+                "tslib": "^2.4.1"
+            }
+        },
+        "node_modules/@floating-ui/core": {
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.11"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-            "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+            "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/core": "^1.7.3",
-                "@floating-ui/utils": "^0.2.10"
+                "@floating-ui/core": "^1.7.5",
+                "@floating-ui/utils": "^0.2.11"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-            "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@foliojs-fork/fontkit": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.2.tgz",
+            "integrity": "sha512-IfB5EiIb+GZk+77TRB86AHroVaqfq8JRFlUbz0WEwsInyCG0epX2tCPOy+UfaWPju30DeVoUAXfzWXmhn753KA==",
             "dev": true,
             "license": "MIT",
-            "peer": true
+            "dependencies": {
+                "@foliojs-fork/restructure": "^2.0.2",
+                "brotli": "^1.2.0",
+                "clone": "^1.0.4",
+                "deep-equal": "^1.0.0",
+                "dfa": "^1.2.0",
+                "tiny-inflate": "^1.0.2",
+                "unicode-properties": "^1.2.2",
+                "unicode-trie": "^2.0.0"
+            }
+        },
+        "node_modules/@foliojs-fork/linebreak": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.2.tgz",
+            "integrity": "sha512-ZPohpxxbuKNE0l/5iBJnOAfUaMACwvUIKCvqtWGKIMv1lPYoNjYXRfhi9FeeV9McBkBLxsMFWTVVhHJA8cyzvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "1.3.1",
+                "unicode-trie": "^2.0.0"
+            }
+        },
+        "node_modules/@foliojs-fork/pdfkit": {
+            "version": "0.15.3",
+            "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.15.3.tgz",
+            "integrity": "sha512-Obc0Wmy3bm7BINFVvPhcl2rnSSK61DQrlHU8aXnAqDk9LCjWdUOPwhgD8Ywz5VtuFjRxmVOM/kQ/XLIBjDvltw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@foliojs-fork/fontkit": "^1.9.2",
+                "@foliojs-fork/linebreak": "^1.1.1",
+                "crypto-js": "^4.2.0",
+                "jpeg-exif": "^1.1.4",
+                "png-js": "^1.0.0"
+            }
+        },
+        "node_modules/@foliojs-fork/restructure": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
+            "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
@@ -1910,25 +2038,25 @@
             }
         },
         "node_modules/@inquirer/ansi": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
-            "integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+            "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@inquirer/checkbox": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.0.tgz",
-            "integrity": "sha512-5+Q3PKH35YsnoPTh75LucALdAxom6xh5D1oeY561x4cqBuH24ZFVyFREPe14xgnrtmGu3EEt1dIi60wRVSnGCw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+            "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/ansi": "^1.0.1",
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/figures": "^1.0.14",
-                "@inquirer/type": "^3.0.9",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -1943,13 +2071,13 @@
             }
         },
         "node_modules/@inquirer/confirm": {
-            "version": "5.1.19",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.19.tgz",
-            "integrity": "sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==",
+            "version": "5.1.21",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+            "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/type": "^3.0.9"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -1964,19 +2092,19 @@
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
-            "integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
+            "version": "10.3.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+            "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/ansi": "^1.0.1",
-                "@inquirer/figures": "^1.0.14",
-                "@inquirer/type": "^3.0.9",
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
                 "cli-width": "^4.1.0",
                 "mute-stream": "^2.0.0",
                 "signal-exit": "^4.1.0",
                 "wrap-ansi": "^6.2.0",
-                "yoctocolors-cjs": "^2.1.2"
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -2049,14 +2177,14 @@
             }
         },
         "node_modules/@inquirer/editor": {
-            "version": "4.2.21",
-            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.21.tgz",
-            "integrity": "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==",
+            "version": "4.2.23",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+            "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/external-editor": "^1.0.2",
-                "@inquirer/type": "^3.0.9"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/external-editor": "^1.0.3",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -2071,14 +2199,14 @@
             }
         },
         "node_modules/@inquirer/expand": {
-            "version": "4.0.21",
-            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.21.tgz",
-            "integrity": "sha512-+mScLhIcbPFmuvU3tAGBed78XvYHSvCl6dBiYMlzCLhpr0bzGzd8tfivMMeqND6XZiaZ1tgusbUHJEfc6YzOdA==",
+            "version": "4.0.23",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+            "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/type": "^3.0.9",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -2093,12 +2221,12 @@
             }
         },
         "node_modules/@inquirer/external-editor": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
-            "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+            "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
             "license": "MIT",
             "dependencies": {
-                "chardet": "^2.1.0",
+                "chardet": "^2.1.1",
                 "iconv-lite": "^0.7.0"
             },
             "engines": {
@@ -2114,9 +2242,9 @@
             }
         },
         "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-            "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2130,22 +2258,22 @@
             }
         },
         "node_modules/@inquirer/figures": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
-            "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+            "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@inquirer/input": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.5.tgz",
-            "integrity": "sha512-7GoWev7P6s7t0oJbenH0eQ0ThNdDJbEAEtVt9vsrYZ9FulIokvd823yLyhQlWHJPGce1wzP53ttfdCZmonMHyA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+            "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/type": "^3.0.9"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -2160,13 +2288,13 @@
             }
         },
         "node_modules/@inquirer/number": {
-            "version": "3.0.21",
-            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.21.tgz",
-            "integrity": "sha512-5QWs0KGaNMlhbdhOSCFfKsW+/dcAVC2g4wT/z2MCiZM47uLgatC5N20kpkDQf7dHx+XFct/MJvvNGy6aYJn4Pw==",
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+            "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/type": "^3.0.9"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -2181,14 +2309,14 @@
             }
         },
         "node_modules/@inquirer/password": {
-            "version": "4.0.21",
-            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.21.tgz",
-            "integrity": "sha512-xxeW1V5SbNFNig2pLfetsDb0svWlKuhmr7MPJZMYuDnCTkpVBI+X/doudg4pznc1/U+yYmWFFOi4hNvGgUo7EA==",
+            "version": "4.0.23",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+            "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/ansi": "^1.0.1",
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/type": "^3.0.9"
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -2203,21 +2331,21 @@
             }
         },
         "node_modules/@inquirer/prompts": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.9.0.tgz",
-            "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+            "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/checkbox": "^4.3.0",
-                "@inquirer/confirm": "^5.1.19",
-                "@inquirer/editor": "^4.2.21",
-                "@inquirer/expand": "^4.0.21",
-                "@inquirer/input": "^4.2.5",
-                "@inquirer/number": "^3.0.21",
-                "@inquirer/password": "^4.0.21",
-                "@inquirer/rawlist": "^4.1.9",
-                "@inquirer/search": "^3.2.0",
-                "@inquirer/select": "^4.4.0"
+                "@inquirer/checkbox": "^4.3.2",
+                "@inquirer/confirm": "^5.1.21",
+                "@inquirer/editor": "^4.2.23",
+                "@inquirer/expand": "^4.0.23",
+                "@inquirer/input": "^4.3.1",
+                "@inquirer/number": "^3.0.23",
+                "@inquirer/password": "^4.0.23",
+                "@inquirer/rawlist": "^4.1.11",
+                "@inquirer/search": "^3.2.2",
+                "@inquirer/select": "^4.4.2"
             },
             "engines": {
                 "node": ">=18"
@@ -2232,14 +2360,14 @@
             }
         },
         "node_modules/@inquirer/rawlist": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.9.tgz",
-            "integrity": "sha512-AWpxB7MuJrRiSfTKGJ7Y68imYt8P9N3Gaa7ySdkFj1iWjr6WfbGAhdZvw/UnhFXTHITJzxGUI9k8IX7akAEBCg==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+            "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/type": "^3.0.9",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -2254,15 +2382,15 @@
             }
         },
         "node_modules/@inquirer/search": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.0.tgz",
-            "integrity": "sha512-a5SzB/qrXafDX1Z4AZW3CsVoiNxcIYCzYP7r9RzrfMpaLpB+yWi5U8BWagZyLmwR0pKbbL5umnGRd0RzGVI8bQ==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+            "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/figures": "^1.0.14",
-                "@inquirer/type": "^3.0.9",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -2277,16 +2405,16 @@
             }
         },
         "node_modules/@inquirer/select": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.0.tgz",
-            "integrity": "sha512-kaC3FHsJZvVyIjYBs5Ih8y8Bj4P/QItQWrZW22WJax7zTN+ZPXVGuOM55vzbdCP9zKUiBd9iEJVdesujfF+cAA==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+            "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/ansi": "^1.0.1",
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/figures": "^1.0.14",
-                "@inquirer/type": "^3.0.9",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -2301,9 +2429,9 @@
             }
         },
         "node_modules/@inquirer/type": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
-            "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+            "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -2323,27 +2451,6 @@
             "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@isaacs/balanced-match": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-            "license": "MIT",
-            "dependencies": {
-                "@isaacs/balanced-match": "^4.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            }
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.12",
@@ -2509,26 +2616,26 @@
             "license": "MIT"
         },
         "node_modules/@lit-labs/ssr-dom-shim": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
-            "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+            "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
             "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@lit/reactive-element": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
-            "integrity": "sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+            "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.4.0"
+                "@lit-labs/ssr-dom-shim": "^1.5.0"
             }
         },
         "node_modules/@mui/core-downloads-tracker": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.4.tgz",
-            "integrity": "sha512-BIktMapG3r4iXwIhYNpvk97ZfYWTreBBQTWjQKbNbzI64+ULHfYavQEX2w99aSWHS58DvXESWIgbD9adKcUOBw==",
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.11.tgz",
+            "integrity": "sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2537,13 +2644,13 @@
             }
         },
         "node_modules/@mui/icons-material": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.4.tgz",
-            "integrity": "sha512-9n6Xcq7molXWYb680N2Qx+FRW8oT6j/LXF5PZFH3ph9X/Rct0B/BlLAsFI7iL9ySI6LVLuQIVtrLiPT82R7OZw==",
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.11.tgz",
+            "integrity": "sha512-+hz5ilwHZ3djd5es3sCErLioqe/NhZcYTsV/TNXZAMdJdb23F4xzJjqnnZdnurc3S1+ietcssRNqieOhPQLZ7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.4"
+                "@babel/runtime": "^7.28.6"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -2553,7 +2660,7 @@
                 "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "@mui/material": "^7.3.4",
+                "@mui/material": "^7.3.11",
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
@@ -2564,24 +2671,23 @@
             }
         },
         "node_modules/@mui/material": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
-            "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.11.tgz",
+            "integrity": "sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.28.4",
-                "@mui/core-downloads-tracker": "^7.3.4",
-                "@mui/system": "^7.3.3",
-                "@mui/types": "^7.4.7",
-                "@mui/utils": "^7.3.3",
+                "@babel/runtime": "^7.28.6",
+                "@mui/core-downloads-tracker": "^7.3.11",
+                "@mui/system": "^7.3.11",
+                "@mui/types": "^7.4.12",
+                "@mui/utils": "^7.3.11",
                 "@popperjs/core": "^2.11.8",
                 "@types/react-transition-group": "^4.4.12",
                 "clsx": "^2.1.1",
-                "csstype": "^3.1.3",
+                "csstype": "^3.2.3",
                 "prop-types": "^15.8.1",
-                "react-is": "^19.1.1",
+                "react-is": "^19.2.3",
                 "react-transition-group": "^4.4.5"
             },
             "engines": {
@@ -2594,7 +2700,7 @@
             "peerDependencies": {
                 "@emotion/react": "^11.5.0",
                 "@emotion/styled": "^11.3.0",
-                "@mui/material-pigment-css": "^7.3.3",
+                "@mui/material-pigment-css": "^7.3.11",
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2615,21 +2721,21 @@
             }
         },
         "node_modules/@mui/material/node_modules/react-is": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-            "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+            "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@mui/private-theming": {
-            "version": "7.3.3",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.3.tgz",
-            "integrity": "sha512-OJM+9nj5JIyPUvsZ5ZjaeC9PfktmK+W5YaVLToLR8L0lB/DGmv1gcKE43ssNLSvpoW71Hct0necfade6+kW3zQ==",
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.11.tgz",
+            "integrity": "sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.4",
-                "@mui/utils": "^7.3.3",
+                "@babel/runtime": "^7.28.6",
+                "@mui/utils": "^7.3.11",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -2650,17 +2756,17 @@
             }
         },
         "node_modules/@mui/styled-engine": {
-            "version": "7.3.3",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.3.tgz",
-            "integrity": "sha512-CmFxvRJIBCEaWdilhXMw/5wFJ1+FT9f3xt+m2pPXhHPeVIbBg9MnMvNSJjdALvnQJMPw8jLhrUtXmN7QAZV2fw==",
+            "version": "7.3.10",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
+            "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.4",
+                "@babel/runtime": "^7.28.6",
                 "@emotion/cache": "^11.14.0",
                 "@emotion/serialize": "^1.3.3",
                 "@emotion/sheet": "^1.4.0",
-                "csstype": "^3.1.3",
+                "csstype": "^3.2.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -2685,20 +2791,19 @@
             }
         },
         "node_modules/@mui/system": {
-            "version": "7.3.3",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.3.tgz",
-            "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.11.tgz",
+            "integrity": "sha512-7izwGWdNawAKpBKcRlx7f2gFnAAjmASBWvMcyX4YYEeLOFsbfGRbUYGInvnAcUeql3rPxI7F9Ft4oY2OLRz44g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.28.4",
-                "@mui/private-theming": "^7.3.3",
-                "@mui/styled-engine": "^7.3.3",
-                "@mui/types": "^7.4.7",
-                "@mui/utils": "^7.3.3",
+                "@babel/runtime": "^7.28.6",
+                "@mui/private-theming": "^7.3.11",
+                "@mui/styled-engine": "^7.3.10",
+                "@mui/types": "^7.4.12",
+                "@mui/utils": "^7.3.11",
                 "clsx": "^2.1.1",
-                "csstype": "^3.1.3",
+                "csstype": "^3.2.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -2727,13 +2832,13 @@
             }
         },
         "node_modules/@mui/types": {
-            "version": "7.4.7",
-            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.7.tgz",
-            "integrity": "sha512-8vVje9rdEr1rY8oIkYgP+Su5Kwl6ik7O3jQ0wl78JGSmiZhRHV+vkjooGdKD8pbtZbutXFVTWQYshu2b3sG9zw==",
+            "version": "7.4.12",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
+            "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.4"
+                "@babel/runtime": "^7.28.6"
             },
             "peerDependencies": {
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2745,18 +2850,18 @@
             }
         },
         "node_modules/@mui/utils": {
-            "version": "7.3.3",
-            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.3.tgz",
-            "integrity": "sha512-kwNAUh7bLZ7mRz9JZ+6qfRnnxbE4Zuc+RzXnhSpRSxjTlSTj7b4JxRLXpG+MVtPVtqks5k/XC8No1Vs3x4Z2gg==",
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
+            "integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.4",
-                "@mui/types": "^7.4.7",
+                "@babel/runtime": "^7.28.6",
+                "@mui/types": "^7.4.12",
                 "@types/prop-types": "^15.7.15",
                 "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
-                "react-is": "^19.1.1"
+                "react-is": "^19.2.3"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -2776,26 +2881,26 @@
             }
         },
         "node_modules/@mui/utils/node_modules/react-is": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-            "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+            "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@mui/x-data-grid": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.28.3.tgz",
-            "integrity": "sha512-T2Vd+3pAnI7UD3B1y+Z7e1eB9N7PCgPbn44KhxM3iT1ldT49HHQ7c2wDHm2Qf4F5UHL6dxvsBF3sGnGyfo+JOA==",
+            "version": "8.29.2",
+            "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-8.29.2.tgz",
+            "integrity": "sha512-AnH3yQJZXUB+Dv2CtSx8J1XBU1y4GTbq3MCC+r0CCTtglB032K4UhbyeMXG6FLFqWDn1nKofcBNYVoNv5ELR4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/x-internals": "7.28.0",
+                "@babel/runtime": "^7.28.4",
+                "@mui/utils": "^7.3.5",
+                "@mui/x-internals": "8.29.2",
+                "@mui/x-virtualizer": "0.4.1",
                 "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
-                "reselect": "^5.1.1",
-                "use-sync-external-store": "^1.0.0"
+                "use-sync-external-store": "^1.6.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -2807,8 +2912,8 @@
             "peerDependencies": {
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
-                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
@@ -2822,21 +2927,19 @@
             }
         },
         "node_modules/@mui/x-data-grid-pro": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@mui/x-data-grid-pro/-/x-data-grid-pro-7.28.3.tgz",
-            "integrity": "sha512-LPycq0I/plpOBaKPQmOx0iE5azWsMUvFcxO/6CRKJj59KtIVTldfMm7Op4uFmTDjMG/koCxc9TUO+JwoltwR5w==",
+            "version": "8.29.2",
+            "resolved": "https://registry.npmjs.org/@mui/x-data-grid-pro/-/x-data-grid-pro-8.29.2.tgz",
+            "integrity": "sha512-F3B/9nI/x6Qmxx9FKg0/b8+xLuz0M8gaaxIOuG5ydlgNh3EnNmIvEVmMfntkYxogGezyb15utgDkm328ttv35g==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/x-data-grid": "7.28.3",
-                "@mui/x-internals": "7.28.0",
-                "@mui/x-license": "7.28.0",
-                "@types/format-util": "^1.0.4",
+                "@babel/runtime": "^7.28.4",
+                "@mui/utils": "^7.3.5",
+                "@mui/x-data-grid": "8.29.2",
+                "@mui/x-internals": "8.29.2",
+                "@mui/x-license": "8.29.2",
                 "clsx": "^2.1.1",
-                "prop-types": "^15.8.1",
-                "reselect": "^5.1.1"
+                "prop-types": "^15.8.1"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -2844,8 +2947,8 @@
             "peerDependencies": {
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
-                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
@@ -2858,35 +2961,17 @@
                 }
             }
         },
-        "node_modules/@mui/x-data-grid-pro/node_modules/@mui/x-license": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@mui/x-license/-/x-license-7.28.0.tgz",
-            "integrity": "sha512-z50lVN4KxW+KB3usEnorEarbWtBxpYQrWfkmJqwJZEaeDO870LghBuhXNt4KEE2jqUU64MQCgZRPszIyrAvXfQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE",
-            "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/x-internals": "7.28.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
         "node_modules/@mui/x-date-pickers": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.28.3.tgz",
-            "integrity": "sha512-5umKB/DIMfDN+FAlzcrocix9PpoJDJ+5hMdlby8spTPObP4wCSN+wkEhk0vFC7qE9FAWXr4wjemaKvsNf41cCw==",
+            "version": "8.29.2",
+            "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.29.2.tgz",
+            "integrity": "sha512-02efypE9TqoBEMAJ/kzS5al1suo9E2iStuItZnBlQ8/DdLtKHpeeXgK4KNabCg+e4SeF+XuBbu06vL7sNnbXvg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/x-internals": "7.28.0",
-                "@types/react-transition-group": "^4.4.11",
+                "@babel/runtime": "^7.28.4",
+                "@mui/utils": "^7.3.5",
+                "@mui/x-internals": "8.29.2",
+                "@types/react-transition-group": "^4.4.12",
                 "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
                 "react-transition-group": "^4.4.5"
@@ -2901,8 +2986,8 @@
             "peerDependencies": {
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
-                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
                 "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
                 "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
                 "dayjs": "^1.10.7",
@@ -2944,17 +3029,17 @@
             }
         },
         "node_modules/@mui/x-date-pickers-pro": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@mui/x-date-pickers-pro/-/x-date-pickers-pro-7.28.3.tgz",
-            "integrity": "sha512-z5zV9kKYJel4Grx8u3YJEeEmloXdG/vYYwuWbA75cXoYtZfEfyhg6pp7sB2hy8zat4rEmjcFx8oz4BQVmBeYoQ==",
+            "version": "8.29.2",
+            "resolved": "https://registry.npmjs.org/@mui/x-date-pickers-pro/-/x-date-pickers-pro-8.29.2.tgz",
+            "integrity": "sha512-/F0q4URlF69dhVdZDgoycNeSTsjbMFNjMcOZLLLmrjk/byZlbRXe9UZrko8tDn1Scnb30I/xJddHPpMkMaykQQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/x-date-pickers": "7.28.3",
-                "@mui/x-internals": "7.28.0",
-                "@mui/x-license": "7.28.0",
+                "@babel/runtime": "^7.28.4",
+                "@mui/utils": "^7.3.5",
+                "@mui/x-date-pickers": "8.29.2",
+                "@mui/x-internals": "8.29.2",
+                "@mui/x-license": "8.29.2",
                 "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
                 "react-transition-group": "^4.4.5"
@@ -2965,8 +3050,8 @@
             "peerDependencies": {
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
-                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
                 "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
                 "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
                 "dayjs": "^1.10.7",
@@ -3007,33 +3092,17 @@
                 }
             }
         },
-        "node_modules/@mui/x-date-pickers-pro/node_modules/@mui/x-license": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@mui/x-license/-/x-license-7.28.0.tgz",
-            "integrity": "sha512-z50lVN4KxW+KB3usEnorEarbWtBxpYQrWfkmJqwJZEaeDO870LghBuhXNt4KEE2jqUU64MQCgZRPszIyrAvXfQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE",
-            "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-                "@mui/x-internals": "7.28.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
         "node_modules/@mui/x-internals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.28.0.tgz",
-            "integrity": "sha512-p4GEp/09bLDumktdIMiw+OF4p+pJOOjTG0VUvzNxjbHB9GxbBKoMcHrmyrURqoBnQpWIeFnN/QAoLMFSpfwQbw==",
+            "version": "8.29.2",
+            "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.29.2.tgz",
+            "integrity": "sha512-TLILyHia5NHh3MGErFDh0bXZ4V6iS45hdStofsV5wklF6dpgZjduo65oJB0h81mI5mexNlhHANEVfw0KV6BxBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+                "@babel/runtime": "^7.28.4",
+                "@mui/utils": "^7.3.5",
+                "reselect": "^5.1.1",
+                "use-sync-external-store": "^1.6.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -3047,15 +3116,16 @@
             }
         },
         "node_modules/@mui/x-license": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@mui/x-license/-/x-license-7.29.1.tgz",
-            "integrity": "sha512-+6D4/2IVal8Gfzu7iZS0ZJgL5cMes0gES+uK9D8I4rlMjPQ779N/rXYMe42mGQZbZuRpoqwSq6VLQx3Gr3SkLQ==",
+            "version": "8.29.2",
+            "resolved": "https://registry.npmjs.org/@mui/x-license/-/x-license-8.29.2.tgz",
+            "integrity": "sha512-rq/WGwPkMyu9PpMU/Psa+o7ebXMN6ljxIa0uh5kgptk36TEY8bMdW6cgGbhlTTS83L9/AzTOTBafhUAucsVxbg==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
-                "@mui/x-internals": "7.29.0"
+                "@babel/runtime": "^7.28.4",
+                "@mui/utils": "^7.3.5",
+                "@mui/x-internals": "8.29.2",
+                "@mui/x-telemetry": "8.29.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -3064,38 +3134,53 @@
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@mui/x-license/node_modules/@mui/x-internals": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
-            "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+        "node_modules/@mui/x-telemetry": {
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@mui/x-telemetry/-/x-telemetry-8.29.0.tgz",
+            "integrity": "sha512-U2fDXtC6Y5z1HwQGS4z+nKl/Eui/spNVdQITTZDKojNLTs4ql/sMxIoetz49CY2Rs9F/51UrXcnT1qLDLsdaHA==",
             "dev": true,
-            "license": "MIT",
+            "hasInstallScript": true,
+            "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+                "@babel/runtime": "^7.28.4",
+                "@fingerprintjs/fingerprintjs": "^3.4.2",
+                "ci-info": "^4.3.1",
+                "conf": "^11.0.2",
+                "is-docker": "^4.0.0",
+                "node-machine-id": "^1.1.12"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@mui/x-telemetry/node_modules/is-docker": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+            "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
             },
             "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@mui/x-tree-view": {
-            "version": "7.29.10",
-            "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-7.29.10.tgz",
-            "integrity": "sha512-/ZcM582yIaQN2PmadIlQYRJzc3yXV7bh463J4GHtTmFw+PEjzUfzETBWe3VxmU3EPgIFzVQPjqAAJwylmQSJOg==",
+            "version": "8.29.2",
+            "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-8.29.2.tgz",
+            "integrity": "sha512-HpgT5SDhP/YhOUWnXw+J+GlYaQUM1TwWM6nayDNM33GEVFMRQ29/dbNtVk7woZkF5Uw9fpgp53ZoYU1dByi9ig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
-                "@mui/x-internals": "7.29.0",
-                "@types/react-transition-group": "^4.4.11",
+                "@babel/runtime": "^7.28.4",
+                "@base-ui/utils": "^0.2.3",
+                "@mui/utils": "^7.3.5",
+                "@mui/x-internals": "8.29.2",
+                "@types/react-transition-group": "^4.4.12",
                 "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
                 "react-transition-group": "^4.4.5"
@@ -3124,15 +3209,16 @@
                 }
             }
         },
-        "node_modules/@mui/x-tree-view/node_modules/@mui/x-internals": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
-            "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+        "node_modules/@mui/x-virtualizer": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@mui/x-virtualizer/-/x-virtualizer-0.4.1.tgz",
+            "integrity": "sha512-EM4lCW9MFRHxAgdqBG6nRQXlrhctlHqOjPm95usht15JBXtuWwtuVdA5q8ta+EwXE9zF0BcKyQsGs8R/vWzmFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
-                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+                "@babel/runtime": "^7.28.4",
+                "@mui/utils": "^7.3.5",
+                "@mui/x-internals": "8.29.2"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -3142,7 +3228,8 @@
                 "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
@@ -3154,6 +3241,18 @@
                 "@emnapi/core": "^1.4.3",
                 "@emnapi/runtime": "^1.4.3",
                 "@tybys/wasm-util": "^0.10.0"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -3198,14 +3297,161 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@polymer/polymer": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
-            "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
-            "dev": true,
-            "license": "BSD-3-Clause",
+        "node_modules/@peculiar/asn1-cms": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+            "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+            "license": "MIT",
             "dependencies": {
-                "@webcomponents/shadycss": "^1.9.1"
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-x509-attr": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-csr": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+            "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-ecc": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+            "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pfx": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+            "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.8.0",
+                "@peculiar/asn1-pkcs8": "^2.8.0",
+                "@peculiar/asn1-rsa": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs8": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+            "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs9": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+            "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.8.0",
+                "@peculiar/asn1-pfx": "^2.8.0",
+                "@peculiar/asn1-pkcs8": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-x509-attr": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-rsa": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+            "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-schema": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+            "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+            "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+            "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/x509": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+            "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.0",
+                "@peculiar/asn1-csr": "^2.6.0",
+                "@peculiar/asn1-ecc": "^2.6.0",
+                "@peculiar/asn1-pkcs9": "^2.6.0",
+                "@peculiar/asn1-rsa": "^2.6.0",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.0",
+                "pvtsutils": "^1.3.6",
+                "reflect-metadata": "^0.2.2",
+                "tslib": "^2.8.1",
+                "tsyringe": "^4.10.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@popperjs/core": {
@@ -3255,16 +3501,37 @@
                 "tinyglobby": "^0.2.14"
             }
         },
-        "node_modules/@ts-morph/common/node_modules/minimatch": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-            "license": "BlueOak-1.0.0",
+        "node_modules/@ts-morph/common/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "license": "MIT",
             "dependencies": {
-                "@isaacs/brace-expansion": "^5.0.0"
+                "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -3317,22 +3584,325 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/eslint": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+        "node_modules/@types/d3": {
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+            "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/estree": "*",
-                "@types/json-schema": "*"
+                "@types/d3-array": "*",
+                "@types/d3-axis": "*",
+                "@types/d3-brush": "*",
+                "@types/d3-chord": "*",
+                "@types/d3-color": "*",
+                "@types/d3-contour": "*",
+                "@types/d3-delaunay": "*",
+                "@types/d3-dispatch": "*",
+                "@types/d3-drag": "*",
+                "@types/d3-dsv": "*",
+                "@types/d3-ease": "*",
+                "@types/d3-fetch": "*",
+                "@types/d3-force": "*",
+                "@types/d3-format": "*",
+                "@types/d3-geo": "*",
+                "@types/d3-hierarchy": "*",
+                "@types/d3-interpolate": "*",
+                "@types/d3-path": "*",
+                "@types/d3-polygon": "*",
+                "@types/d3-quadtree": "*",
+                "@types/d3-random": "*",
+                "@types/d3-scale": "*",
+                "@types/d3-scale-chromatic": "*",
+                "@types/d3-selection": "*",
+                "@types/d3-shape": "*",
+                "@types/d3-time": "*",
+                "@types/d3-time-format": "*",
+                "@types/d3-timer": "*",
+                "@types/d3-transition": "*",
+                "@types/d3-zoom": "*"
             }
         },
-        "node_modules/@types/eslint-scope": {
-            "version": "3.7.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-axis": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+            "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/eslint": "*",
-                "@types/estree": "*"
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-brush": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+            "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-chord": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+            "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-contour": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+            "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-array": "*",
+                "@types/geojson": "*"
+            }
+        },
+        "node_modules/@types/d3-delaunay": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+            "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-dispatch": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+            "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-drag": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+            "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-dsv": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+            "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-fetch": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+            "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-dsv": "*"
+            }
+        },
+        "node_modules/@types/d3-force": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+            "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-format": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+            "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-geo": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+            "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/geojson": "*"
+            }
+        },
+        "node_modules/@types/d3-hierarchy": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.1.tgz",
+            "integrity": "sha512-QwjxA3+YCKH3N1Rs3uSiSy1bdxlLB1uUiENXeJudBoAFvtDuswUxLcanoOaR2JYn1melDTuIXR8VhnVyI3yG/A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-polygon": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+            "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-quadtree": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+            "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-random": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+            "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-sankey": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-sankey/-/d3-sankey-0.11.2.tgz",
+            "integrity": "sha512-U6SrTWUERSlOhnpSrgvMX64WblX1AxX6nEjI2t3mLK2USpQrnbwYYK+AS9SwiE7wgYmOsSSKoSdr8aoKBH0HgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-shape": "^1"
+            }
+        },
+        "node_modules/@types/d3-sankey/node_modules/@types/d3-path": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
+            "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
+            "version": "1.3.12",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
+            "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "^1"
+            }
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-scale-chromatic": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+            "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-selection": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+            "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-time-format": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+            "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-transition": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+            "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-zoom": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+            "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-interpolate": "*",
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/debug": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+            "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/ms": "*"
             }
         },
         "node_modules/@types/estree": {
@@ -3340,6 +3910,16 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "license": "MIT"
+        },
+        "node_modules/@types/estree-jsx": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+            "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
         },
         "node_modules/@types/express": {
             "version": "4.17.25",
@@ -3365,12 +3945,22 @@
                 "@types/send": "*"
             }
         },
-        "node_modules/@types/format-util": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@types/format-util/-/format-util-1.0.4.tgz",
-            "integrity": "sha512-xrCYOdHh5zA3LUrn6CvspYwlzSWxPso11Lx32WnAG6KvLCRecKZ/Rh21PLXUkzUFsQmrGcx/traJAFjR6dVS5Q==",
+        "node_modules/@types/geojson": {
+            "version": "7946.0.16",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+            "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
         },
         "node_modules/@types/html-minifier-terser": {
             "version": "6.1.0",
@@ -3403,10 +3993,27 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
         },
+        "node_modules/@types/mdast": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+            "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
         "node_modules/@types/mime": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+            "license": "MIT"
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/node": {
@@ -3414,24 +4021,22 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.17.tgz",
             "integrity": "sha512-nAJuQXoyPj04uLgu+obZcSmsfOenUg6DxPKogeUy6yNCFwWaj5sBF8/G/pNo8EtBJjAfSVgfIlugR/BCOleO+g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
-            }
-        },
-        "node_modules/@types/node-forge": {
-            "version": "1.3.14",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-            "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
             }
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/polylabel": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@types/polylabel/-/polylabel-1.1.3.tgz",
+            "integrity": "sha512-9Zw2KoDpi+T4PZz2G6pO2xArE0m/GSMTW1MIxF2s8ZY8x9XDO6fv9um0ydRGvcbkFLlaq8yNK6eZxnmMZtDgWQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3460,7 +4065,6 @@
             "integrity": "sha512-nNCvVBcZlvX4NU1nRRNV/mFl1nNRuTuslAJglQsq+8ldXe5Xv0Wd2f7WTE3jOxhLH2BFfiZGC6GCp+kHQbgG+w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -3559,9 +4163,16 @@
             }
         },
         "node_modules/@types/sortablejs": {
-            "version": "1.15.8",
-            "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
-            "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
+            "version": "1.15.9",
+            "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
+            "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/svg-arc-to-cubic-bezier": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@types/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.3.tgz",
+            "integrity": "sha512-UNOnbTtl0nVTm8hwKaz5R5VZRvSulFMGojO5+Q7yucKxBoCaTtS4ibSQVRHo5VW5AaRo145U8p1Vfg5KrYe9Bg==",
             "dev": true,
             "license": "MIT"
         },
@@ -3569,6 +4180,13 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -3586,7 +4204,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.38.0.tgz",
             "integrity": "sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
                 "@typescript-eslint/scope-manager": "8.38.0",
@@ -3625,7 +4242,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.38.0.tgz",
             "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.38.0",
                 "@typescript-eslint/types": "8.38.0",
@@ -3815,6 +4431,13 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+            "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
             "version": "1.11.1",
@@ -4048,118 +4671,91 @@
             ]
         },
         "node_modules/@vaadin/a11y-base": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.7.12.tgz",
-            "integrity": "sha512-y/wWMADMmcXmY9sJ/TF+xh+HP+nE4Jc61SpW/D98c5zrLnf4cFlqTJEl8YwLDv80HtG78ieyzMHhvw9Wv96sdQ==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-25.0.13.tgz",
+            "integrity": "sha512-Rx1pCYbFfpQh03Myr/5F8WtY8IPYf31Sk/hHNYhxxF+e6yHZZOqU+NhA8sDiYQI48RyRnSyzPtG6mdp/WJgN6w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/component-base": "~24.7.12",
+                "@vaadin/component-base": "~25.0.13",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/checkbox": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.7.12.tgz",
-            "integrity": "sha512-9zERd1yc2FUhP3/NLdSITVg1QiRE9hiLbyIBRBEmkkuiU/zTRAAlDndFLeZKGDkIEtbLoz2Dcg5DoNNFnLA6qg==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-25.0.13.tgz",
+            "integrity": "sha512-L6bS9aGCAvgiKnQ2gBR/t7bCCRmXX4H/eDqRViNFjbMMjbgQT3Ms9C5ASEpRp7/+4JfRnmsouihZ5g48pY+a5Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/a11y-base": "~24.7.12",
-                "@vaadin/component-base": "~24.7.12",
-                "@vaadin/field-base": "~24.7.12",
-                "@vaadin/vaadin-lumo-styles": "~24.7.12",
-                "@vaadin/vaadin-material-styles": "~24.7.12",
-                "@vaadin/vaadin-themable-mixin": "~24.7.12",
+                "@vaadin/a11y-base": "~25.0.13",
+                "@vaadin/component-base": "~25.0.13",
+                "@vaadin/field-base": "~25.0.13",
+                "@vaadin/vaadin-themable-mixin": "~25.0.13",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/component-base": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.12.tgz",
-            "integrity": "sha512-GuHHRxaQKW7p5RIZxAqGEhYCSqF4CLpxXB/IPY4IW+4G/SzoIe8EqyneNnUSoKMoAFkBp0+A6tlJoWR9uvLTnQ==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-25.0.13.tgz",
+            "integrity": "sha512-cminL+elKXuhnWHXGWaYluTtgA8X2+Ha+/UKrPVPP3THgG7nOcXCVFrRdnhCeokpHHR/8/ya56QbN8qBJYuRVQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@polymer/polymer": "^3.0.0",
                 "@vaadin/vaadin-development-mode-detector": "^2.0.0",
                 "@vaadin/vaadin-usage-statistics": "^2.1.0",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/field-base": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.7.12.tgz",
-            "integrity": "sha512-DNnFkhlShRLsZ6LJZq9VhtG+pexObp9sNkk22Lx3g9PyrpuEllTJwGw/jEUE9jyI8dsgkCHRVZ+krxE026NFsg==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-25.0.13.tgz",
+            "integrity": "sha512-aPK6LCXh1TuoHUf3wEHUI50ALXgwCJMOBQCNxCzCQZ9YQ1AKqI/OF0dB9T7OUT/Yv71D/SuDm0dzemqGcOXmuw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/a11y-base": "~24.7.12",
-                "@vaadin/component-base": "~24.7.12",
+                "@vaadin/a11y-base": "~25.0.13",
+                "@vaadin/component-base": "~25.0.13",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/grid": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.7.12.tgz",
-            "integrity": "sha512-ks1NfM6o4XJcECETaXBrNCGtCL6nWj1yfLOAHycQ6h+P8dd1UO63ZuLEVl+Ii+kymS2xHmUgJx9EoNrPIqxdlw==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-25.0.13.tgz",
+            "integrity": "sha512-34IdPjud4z8PTUXDiTbbZu7bdIlBcWxhZLfCvZa0itdzRKLHvXiETI3/tD8qEsggY1/za0hYQxR+3HPGoTSJCA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/a11y-base": "~24.7.12",
-                "@vaadin/checkbox": "~24.7.12",
-                "@vaadin/component-base": "~24.7.12",
-                "@vaadin/lit-renderer": "~24.7.12",
-                "@vaadin/text-field": "~24.7.12",
-                "@vaadin/vaadin-lumo-styles": "~24.7.12",
-                "@vaadin/vaadin-material-styles": "~24.7.12",
-                "@vaadin/vaadin-themable-mixin": "~24.7.12",
-                "lit": "^3.0.0"
-            }
-        },
-        "node_modules/@vaadin/icon": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.12.tgz",
-            "integrity": "sha512-8oLr69l22cAw2K+FNd3sCdhw+yWhU5Z1tlp8ZGUTTgyClvpe9pDIdZfBX4pQXnSx6QPNc3CrOaVZkx7n5WQqJg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@open-wc/dedupe-mixin": "^1.3.0",
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/component-base": "~24.7.12",
-                "@vaadin/vaadin-lumo-styles": "~24.7.12",
-                "@vaadin/vaadin-themable-mixin": "~24.7.12",
+                "@vaadin/a11y-base": "~25.0.13",
+                "@vaadin/checkbox": "~25.0.13",
+                "@vaadin/component-base": "~25.0.13",
+                "@vaadin/lit-renderer": "~25.0.13",
+                "@vaadin/text-field": "~25.0.13",
+                "@vaadin/vaadin-themable-mixin": "~25.0.13",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/input-container": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.7.12.tgz",
-            "integrity": "sha512-1oc21Owe9nI/t41TsdVan4b9pa8AjZZl/3t9o6X9XL/E4dHpFcj3lezlHEg92TBNzHm+6DcVPo/kZP29iahWEg==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-25.0.13.tgz",
+            "integrity": "sha512-qTVZv3+QY2Gecvh/1Yicfx+bUN0mRXuYs0Fgay1MtoF7GWPhvZahyUJiVp/qVkfTqyxRB6uD2/flHfmd6iJmAA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/component-base": "~24.7.12",
-                "@vaadin/vaadin-lumo-styles": "~24.7.12",
-                "@vaadin/vaadin-material-styles": "~24.7.12",
-                "@vaadin/vaadin-themable-mixin": "~24.7.12",
+                "@vaadin/component-base": "~25.0.13",
+                "@vaadin/vaadin-themable-mixin": "~25.0.13",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/lit-renderer": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.7.12.tgz",
-            "integrity": "sha512-AjPoLJBUuOJfmnpJpWYDoTDpH3+cXX+YJso7Acm0Ec1PeFAc9PvwGZBLlQK64juvTzejMLVFWYaU4bhn2rXVLA==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-25.0.13.tgz",
+            "integrity": "sha512-2aK/9Xl1xf0sGg2W/orek9YMwirVwY5mSl82ykr5owdufzGosM+y9Zwe8t8Kp6u7ee/hYROs9+EmzCUpgZThAg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -4167,21 +4763,18 @@
             }
         },
         "node_modules/@vaadin/text-field": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.7.12.tgz",
-            "integrity": "sha512-Zymu/9pAg9+FtWLBVpI1Hiev3SCc2mVLCqq7x17pSVD1Kp3Pcd/HIU3v1MivihUx1z7t9Kt0cNk84T9NDADjDw==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-25.0.13.tgz",
+            "integrity": "sha512-oHxST1MnziUBWTq6mB+gQHIljtyZXQs0drtm6tNp2Dwz9FzmCaEiXW6eqgpI2zHqM09Xv9Uhyao1DBwFOAvNHw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/a11y-base": "~24.7.12",
-                "@vaadin/component-base": "~24.7.12",
-                "@vaadin/field-base": "~24.7.12",
-                "@vaadin/input-container": "~24.7.12",
-                "@vaadin/vaadin-lumo-styles": "~24.7.12",
-                "@vaadin/vaadin-material-styles": "~24.7.12",
-                "@vaadin/vaadin-themable-mixin": "~24.7.12",
+                "@vaadin/a11y-base": "~25.0.13",
+                "@vaadin/component-base": "~25.0.13",
+                "@vaadin/field-base": "~25.0.13",
+                "@vaadin/input-container": "~25.0.13",
+                "@vaadin/vaadin-themable-mixin": "~25.0.13",
                 "lit": "^3.0.0"
             }
         },
@@ -4192,39 +4785,15 @@
             "dev": true,
             "license": "Apache-2.0"
         },
-        "node_modules/@vaadin/vaadin-lumo-styles": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.12.tgz",
-            "integrity": "sha512-KMpOEb5uB/JVBGF94pQb5mIbtb6/6tZ2QzfZ1II4/JpKsp7pgpySy5tZFoZrb8M8miOj01sAkSaH99N0DST8dA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/component-base": "~24.7.12",
-                "@vaadin/icon": "~24.7.12",
-                "@vaadin/vaadin-themable-mixin": "~24.7.12"
-            }
-        },
-        "node_modules/@vaadin/vaadin-material-styles": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.7.12.tgz",
-            "integrity": "sha512-WXXA2I+tOt1yxHYn57Boc2fdyLD7kIj5jX8GQMVkBW9nHN9oRfKO8beurmE2Am6Tz/HEMBtybx9ysY1k39TwBQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/component-base": "~24.7.12",
-                "@vaadin/vaadin-themable-mixin": "~24.7.12"
-            }
-        },
         "node_modules/@vaadin/vaadin-themable-mixin": {
-            "version": "24.7.12",
-            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.12.tgz",
-            "integrity": "sha512-BkpnhYj3olUzNlgIhu518//tHJsoCBWabUmfdQCN8MTdT2AjkHDZNjoRy+dL1sbJyhl9EFCACXP+f8q1Qxawsw==",
+            "version": "25.0.13",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-25.0.13.tgz",
+            "integrity": "sha512-GTtNzwVHdezIxyml/yXHNf85Lco5X6ZnpIh1edaX6vIH6P8HVXEEg7nDY2vom5ff1IczjleGbD8nKmP0IsLKCw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
+                "@vaadin/component-base": "~25.0.13",
                 "lit": "^3.0.0"
             }
         },
@@ -4243,13 +4812,14 @@
             }
         },
         "node_modules/@vertigis/arcgis-extensions": {
-            "version": "51.6.0",
-            "resolved": "https://registry.npmjs.org/@vertigis/arcgis-extensions/-/arcgis-extensions-51.6.0.tgz",
-            "integrity": "sha512-Dd8x6CfLlNjaxTybgi2rISlCJ8JVwizhuVU25UCH4x2XrphI8CBYLgxsgyznQPjwNS9QnesqjunRyByOjZzbTw==",
+            "version": "53.17.0",
+            "resolved": "https://registry.npmjs.org/@vertigis/arcgis-extensions/-/arcgis-extensions-53.17.0.tgz",
+            "integrity": "sha512-XubgdBHEYLkwQVCdoXBnNaXtpA0aX8UzN0bL8L5QCBIPek9RmFCcEAGve0awAOkCU2c7LduaxksM4hPNRn04nQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "alasql": "~4.5.2",
+                "dxf-parser": "^1.1.2",
                 "elasticlunr": "~0.9.5",
                 "esri-proj-codes": "~1.0.3",
                 "jszip": "~3.10.1",
@@ -4260,7 +4830,7 @@
                 "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
             },
             "peerDependencies": {
-                "@arcgis/core": "4.33.13",
+                "@arcgis/core": "^5.0.10",
                 "tslib": "^2.6.2"
             }
         },
@@ -4275,24 +4845,28 @@
             }
         },
         "node_modules/@vertigis/react-ui": {
-            "version": "20.0.1",
-            "resolved": "https://registry.npmjs.org/@vertigis/react-ui/-/react-ui-20.0.1.tgz",
-            "integrity": "sha512-ofnBHdEH8pGmwojM7E3gVChy6H3GzWW2VFYAu7VvpZwxzxPdiMH/up998qgAsMpDHY+AIbm0ULMd2NnXPF1XtQ==",
+            "version": "21.10.0",
+            "resolved": "https://registry.npmjs.org/@vertigis/react-ui/-/react-ui-21.10.0.tgz",
+            "integrity": "sha512-ABw3woZMYR3y/BO/U3fJXU1p/UpZ1/JVMveiiDGMYYDIZFEvKP4mYGRL1S0lc3g8FPjFZ/KRlB5FMN0a2o0neg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@mui/icons-material": "^7.2.0",
                 "@mui/material": "^7.2.0",
-                "@mui/x-data-grid-pro": "~7.28.0",
-                "@mui/x-date-pickers-pro": "~7.28.0",
-                "@mui/x-license": "^7.24.1",
-                "@mui/x-tree-view": "^7.24.0",
+                "@mui/x-data-grid-pro": "^8.28.0",
+                "@mui/x-date-pickers-pro": "^8.27.2",
+                "@mui/x-license": "^8.26.0",
+                "@mui/x-tree-view": "^8.27.2",
                 "autosuggest-highlight": "^3.3.4",
                 "clsx": "^2.1.0",
                 "color": "^4.2.3",
                 "lodash.escape": "^4.0.1",
-                "marked": "^12.0.1",
+                "marked": "~15.0.12",
                 "react-color": "^2.19.3",
+                "react-markdown": "^10.1.0",
+                "rehype-raw": "^7.0.0",
+                "rehype-sanitize": "^6.0.0",
+                "remark-gfm": "^4.0.1",
                 "tslib": "^2.6.2",
                 "xss": "^1.0.15"
             },
@@ -4338,9 +4912,9 @@
             "license": "MIT"
         },
         "node_modules/@vertigis/react-ui/node_modules/marked": {
-            "version": "12.0.2",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-            "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+            "version": "15.0.12",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+            "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4368,9 +4942,9 @@
             }
         },
         "node_modules/@vertigis/sdk-library": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@vertigis/sdk-library/-/sdk-library-2.0.1.tgz",
-            "integrity": "sha512-7Q/k6gYTKZnDD+jZX3XPMCsYehx1fvuBkRM9PzmoZ18/o9YUIflRPKBpbIr8bnSik/5qfSuxOfwgOEVYPh42bw==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vertigis/sdk-library/-/sdk-library-2.0.5.tgz",
+            "integrity": "sha512-uXaPEx9Smj/EFN8Sfrr8n71ee3h/aL0RUpFqFdUF55Odydufb4iAo+TyUTOKvKaBYYSzRaB4kcIuVIGOED7fRQ==",
             "license": "MIT",
             "dependencies": {
                 "@eslint/js": "^9.31.0",
@@ -4387,7 +4961,8 @@
                 "fork-ts-checker-webpack-plugin": "~9.0.2",
                 "fs-extra": "^11.3.0",
                 "html-webpack-plugin": "^5.6.4",
-                "inquirer": "^12.9.0",
+                "https-proxy-agent": "^7.0.6",
+                "inquirer": "~12.9.0",
                 "playwright-chromium": "^1.56.1",
                 "postcss": "^8.5.6",
                 "postcss-loader": "^8.1.1",
@@ -4502,31 +5077,31 @@
             }
         },
         "node_modules/@vertigis/viewer-spec": {
-            "version": "59.21.0",
-            "resolved": "https://registry.npmjs.org/@vertigis/viewer-spec/-/viewer-spec-59.21.0.tgz",
-            "integrity": "sha512-RtoOhLDjokGhUFTOp5eoyP5G82yMxUybMC9COyFrjTMSxAvqiDJ+QacmM8IzNURH6nMJFHPX7sIhwFiQGwQo6g==",
+            "version": "61.9.2",
+            "resolved": "https://registry.npmjs.org/@vertigis/viewer-spec/-/viewer-spec-61.9.2.tgz",
+            "integrity": "sha512-9U2Q23/sAtvF5Dar1xdohBMCl9zfojsvnaJ4fbBjWo9SHWkfc8DhcHFZ9IELC6qsWrr3A5jkNVxad7Byl8biaA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE",
             "peerDependencies": {
                 "@arcgis/core": "*",
-                "@vertigis/arcgis-extensions": ">= 51.0.0-0 < 52.0.0-0",
+                "@vertigis/arcgis-extensions": ">= 53.0.0-0 < 54.0.0-0",
                 "highcharts": "*"
             }
         },
         "node_modules/@vertigis/web": {
-            "version": "5.38.0",
-            "resolved": "https://registry.npmjs.org/@vertigis/web/-/web-5.38.0.tgz",
-            "integrity": "sha512-imXZsFhVQviTsjet9JW5rXDTY3CcwjWggJ+TOFJydSUba9c0VUDEryVoyNrnZXyG0VwzH3nYF6GjyOq9WQu5xw==",
+            "version": "5.42.0",
+            "resolved": "https://registry.npmjs.org/@vertigis/web/-/web-5.42.0.tgz",
+            "integrity": "sha512-G7ZptveK+fP9TrRB2k4zao7KZgg7mfiYwKn1s9jWLEp2ZKkFOJbIjod9u4OkXdsTTiXUZsGl7K3R8lPWnLZQFg==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
-                "@arcgis/core": "4.33.13",
+                "@arcgis/core": "5.0.12",
                 "@types/react": "18.2.46",
                 "@types/react-dom": "18.2.18",
                 "@types/react-window": "1.8.8",
-                "@vertigis/arcgis-extensions": "51.6.0",
-                "@vertigis/react-ui": "20.0.1",
-                "@vertigis/viewer-spec": "59.21.0",
+                "@vertigis/arcgis-extensions": "53.17.0",
+                "@vertigis/react-ui": "21.10.0",
+                "@vertigis/viewer-spec": "61.9.2",
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
                 "react-is": "18.2.0"
@@ -4663,13 +5238,6 @@
                 "@xtuc/long": "4.2.2"
             }
         },
-        "node_modules/@webcomponents/shadycss": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
-            "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4681,15 +5249,15 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "node_modules/@zip.js/zip.js": {
-            "version": "2.7.73",
-            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.73.tgz",
-            "integrity": "sha512-I2UP8/rdQE5hTtVVL08B7P8XuwXiKuuMUPjNuFOVL/9b+8IsExR9S5jz2H58u0rJjU4M1BikLgqEMG8gZJZVBw==",
+            "version": "2.8.26",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
+            "integrity": "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "bun": ">=0.7.0",
                 "deno": ">=1.0.0",
-                "node": ">=16.5.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/accepts": {
@@ -4715,11 +5283,10 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4747,11 +5314,20 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "peer": true,
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -4780,14 +5356,15 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
                 "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.4.1"
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
@@ -5044,12 +5621,37 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
             "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/atomically": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+            "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "stubborn-fs": "^2.0.0",
+                "when-exit": "^2.1.4"
             }
         },
         "node_modules/autoprefixer": {
@@ -5119,6 +5721,7 @@
             "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "cosmiconfig": "^7.0.0",
@@ -5129,18 +5732,39 @@
                 "npm": ">=6"
             }
         },
+        "node_modules/bail": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+            "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
+        "node_modules/base64-js": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.8.24",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.24.tgz",
-            "integrity": "sha512-uUhTRDPXamakPyghwrUcjaGvvBqGrWvBHReoiULMIpOJVM9IYzQh83Xk2Onx5HlGI2o10NNCzcs9TG/S3TkwrQ==",
+            "version": "2.10.42",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
             "license": "Apache-2.0",
             "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/batch": {
@@ -5170,9 +5794,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-            "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "~3.1.2",
@@ -5183,7 +5807,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -5254,9 +5878,9 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -5273,10 +5897,30 @@
                 "node": ">=8"
             }
         },
+        "node_modules/brotli": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+            "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.1.2"
+            }
+        },
+        "node_modules/browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pako": "~1.0.5"
+            }
+        },
         "node_modules/browserslist": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
-            "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
+            "version": "4.28.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+            "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5292,13 +5936,12 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "baseline-browser-mapping": "^2.8.19",
-                "caniuse-lite": "^1.0.30001751",
-                "electron-to-chromium": "^1.5.238",
-                "node-releases": "^2.0.26",
-                "update-browserslist-db": "^1.1.4"
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001800",
+                "electron-to-chromium": "^1.5.387",
+                "node-releases": "^2.0.50",
+                "update-browserslist-db": "^1.2.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -5334,6 +5977,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/bytestreamjs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/call-bind": {
@@ -5399,9 +6051,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001753",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
-            "integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
+            "version": "1.0.30001803",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+            "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5418,6 +6070,17 @@
             ],
             "license": "CC-BY-4.0"
         },
+        "node_modules/ccount": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+            "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/chalk": {
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -5431,10 +6094,54 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-entities-html4": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+            "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-entities-legacy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-reference-invalid": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/chardet": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-            "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+            "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
             "license": "MIT"
         },
         "node_modules/chokidar": {
@@ -5477,6 +6184,22 @@
             "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
             "engines": {
                 "node": ">=6.0"
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/clean-css": {
@@ -5611,6 +6334,16 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -5642,14 +6375,14 @@
             "license": "MIT"
         },
         "node_modules/color": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
-            "integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+            "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "color-convert": "^3.0.1",
-                "color-string": "^2.0.0"
+                "color-convert": "^3.1.3",
+                "color-string": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -5672,9 +6405,9 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/color-string": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
-            "integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+            "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5685,9 +6418,9 @@
             }
         },
         "node_modules/color-string/node_modules/color-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
-            "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+            "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5695,9 +6428,9 @@
             }
         },
         "node_modules/color/node_modules/color-convert": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
-            "integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+            "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5708,9 +6441,9 @@
             }
         },
         "node_modules/color/node_modules/color-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
-            "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+            "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5722,6 +6455,17 @@
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "license": "MIT"
+        },
+        "node_modules/comma-separated-tokens": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+            "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/commander": {
             "version": "8.3.0",
@@ -5823,6 +6567,95 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
+        "node_modules/conf": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/conf/-/conf-11.0.2.tgz",
+            "integrity": "sha512-jjyhlQ0ew/iwmtwsS2RaB6s8DBifcE2GYBEaw2SJDUY/slJJbNfY4GlDVzOs/ff8cM/Wua5CikqXgbFl5eu85A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.12.0",
+                "ajv-formats": "^2.1.1",
+                "atomically": "^2.0.0",
+                "debounce-fn": "^5.1.2",
+                "dot-prop": "^7.2.0",
+                "env-paths": "^3.0.0",
+                "json-schema-typed": "^8.0.1",
+                "semver": "^7.3.8"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conf/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/conf/node_modules/dot-prop": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
+            "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^2.11.2"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conf/node_modules/env-paths": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+            "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conf/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/conf/node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/connect-history-api-fallback": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -5891,7 +6724,8 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/cookie": {
             "version": "0.7.1",
@@ -5920,6 +6754,7 @@
             "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -5971,6 +6806,13 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/crypto-js": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/css-blank-pseudo": {
             "version": "7.0.1",
@@ -6145,11 +6987,590 @@
             "license": "MIT"
         },
         "node_modules/csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/d3": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+            "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "3",
+                "d3-axis": "3",
+                "d3-brush": "3",
+                "d3-chord": "3",
+                "d3-color": "3",
+                "d3-contour": "4",
+                "d3-delaunay": "6",
+                "d3-dispatch": "3",
+                "d3-drag": "3",
+                "d3-dsv": "3",
+                "d3-ease": "3",
+                "d3-fetch": "3",
+                "d3-force": "3",
+                "d3-format": "3",
+                "d3-geo": "3",
+                "d3-hierarchy": "3",
+                "d3-interpolate": "3",
+                "d3-path": "3",
+                "d3-polygon": "3",
+                "d3-quadtree": "3",
+                "d3-random": "3",
+                "d3-scale": "4",
+                "d3-scale-chromatic": "3",
+                "d3-selection": "3",
+                "d3-shape": "3",
+                "d3-time": "3",
+                "d3-time-format": "4",
+                "d3-timer": "3",
+                "d3-transition": "3",
+                "d3-zoom": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-axis": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-brush": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "3",
+                "d3-transition": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-chord": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-contour": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-delaunay": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "delaunator": "5"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dispatch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-drag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dsv": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "commander": "7",
+                "iconv-lite": "0.6",
+                "rw": "1"
+            },
+            "bin": {
+                "csv2json": "bin/dsv2json.js",
+                "csv2tsv": "bin/dsv2dsv.js",
+                "dsv2dsv": "bin/dsv2dsv.js",
+                "dsv2json": "bin/dsv2json.js",
+                "json2csv": "bin/json2dsv.js",
+                "json2dsv": "bin/json2dsv.js",
+                "json2tsv": "bin/json2dsv.js",
+                "tsv2csv": "bin/dsv2dsv.js",
+                "tsv2json": "bin/dsv2json.js"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dsv/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/d3-dsv/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-fetch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-dsv": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-force": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-quadtree": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-geo": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+            "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.5.0 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-hierarchy": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-polygon": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-quadtree": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-random": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-sankey": {
+            "version": "0.12.3",
+            "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+            "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "d3-array": "1 - 2",
+                "d3-shape": "^1.2.0"
+            }
+        },
+        "node_modules/d3-sankey/node_modules/d3-array": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+            "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "internmap": "^1.0.0"
+            }
+        },
+        "node_modules/d3-sankey/node_modules/d3-path": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+            "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/d3-sankey/node_modules/d3-shape": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+            "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "d3-path": "1"
+            }
+        },
+        "node_modules/d3-sankey/node_modules/internmap": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale-chromatic": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+            "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-interpolate": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-selection": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-transition": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "d3-selection": "2 - 3"
+            }
+        },
+        "node_modules/d3-voronoi-map": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-voronoi-map/-/d3-voronoi-map-2.1.1.tgz",
+            "integrity": "sha512-mCXfz/kD9IQxjHaU2IMjkO8fSo4J6oysPR2iL+omDsCy1i1Qn6BQ/e4hEAW8C6ms2kfuHwqtbNom80Hih94YsA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "d3-dispatch": "2.*",
+                "d3-polygon": "2.*",
+                "d3-timer": "2.*",
+                "d3-weighted-voronoi": "1.*"
+            }
+        },
+        "node_modules/d3-voronoi-map/node_modules/d3-dispatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+            "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/d3-voronoi-map/node_modules/d3-polygon": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+            "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/d3-voronoi-map/node_modules/d3-timer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+            "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/d3-voronoi-treemap": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/d3-voronoi-treemap/-/d3-voronoi-treemap-1.1.2.tgz",
+            "integrity": "sha512-7odu9HdG/yLPWwzDteJq4yd9Q/NwgQV7IE/u36VQtcCK7k1sZwDqbkHCeMKNTBsq5mQjDwolTsrXcU0j8ZEMCA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "d3-voronoi-map": "2.*"
+            }
+        },
+        "node_modules/d3-weighted-voronoi": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/d3-weighted-voronoi/-/d3-weighted-voronoi-1.1.3.tgz",
+            "integrity": "sha512-C3WdvSKl9aqhAy+f3QT3PPsQG6V+ajDfYO3BSclQDSD+araW2xDBFIH67aKzsSuuuKaX8K2y2dGq1fq/dWTVig==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "d3-array": "2",
+                "d3-polygon": "2"
+            }
+        },
+        "node_modules/d3-weighted-voronoi/node_modules/d3-array": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+            "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "internmap": "^1.0.0"
+            }
+        },
+        "node_modules/d3-weighted-voronoi/node_modules/d3-polygon": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+            "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/d3-weighted-voronoi/node_modules/internmap": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/d3-zoom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
@@ -6199,6 +7620,22 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/debounce-fn": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
+            "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6213,6 +7650,41 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/deep-equal": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+            "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-arguments": "^1.1.1",
+                "is-date-object": "^1.0.5",
+                "is-regex": "^1.1.4",
+                "object-is": "^1.1.5",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.5.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/deep-is": {
@@ -6300,6 +7772,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/delaunator": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+            "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "robust-predicates": "^3.0.2"
+            }
+        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6307,6 +7789,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/destroy": {
@@ -6323,6 +7815,27 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+            "license": "MIT"
+        },
+        "node_modules/devlop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+            "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dequal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/dfa": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/dns-packet": {
@@ -6448,6 +7961,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/dxf-parser": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/dxf-parser/-/dxf-parser-1.1.2.tgz",
+            "integrity": "sha512-GPTumUvRkounlIazLIyJMmTWt+nlg+ksS0Hdm8jWvejmZKBTz6gvHTam76wRm4PQMma5sgKLThblQyeIJcH79Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "loglevel": "^1.7.1"
+            }
+        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6462,9 +7985,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.244",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz",
-            "integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
+            "version": "1.5.388",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz",
+            "integrity": "sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -6492,13 +8015,13 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-            "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+            "version": "5.24.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.3"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -6650,9 +8173,10 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-            "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -6704,9 +8228,9 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.40.0.tgz",
-            "integrity": "sha512-8o6w0KFmU0CiIl0/Q/BCEOabF2IJaELM1T2PWj6e8KqzHv1gdx+7JtFnDwOx1kJH/isJ5NwlDG1nCr1HrRF94Q==",
+            "version": "1.49.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+            "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -6743,7 +8267,6 @@
             "version": "9.37.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
             "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -6916,7 +8439,6 @@
             "version": "2.31.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
             "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.8",
@@ -6946,9 +8468,10 @@
             }
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6974,9 +8497,10 @@
             }
         },
         "node_modules/eslint-plugin-import/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -7068,9 +8592,10 @@
             }
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7088,9 +8613,10 @@
             }
         },
         "node_modules/eslint-plugin-react/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -7164,9 +8690,10 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7200,9 +8727,10 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -7276,6 +8804,17 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-util-is-identifier-name": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+            "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7336,14 +8875,14 @@
             }
         },
         "node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -7362,7 +8901,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -7416,6 +8955,13 @@
             ],
             "license": "MIT"
         },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7460,9 +9006,9 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
         },
         "node_modules/fast-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
             "funding": [
                 {
                     "type": "github",
@@ -7472,7 +9018,8 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fastify"
                 }
-            ]
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.19.1",
@@ -7571,7 +9118,8 @@
             "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
             "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -7609,25 +9157,33 @@
                 "node": ">=16"
             }
         },
+        "node_modules/flatpickr": {
+            "version": "4.6.13",
+            "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+            "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "license": "ISC"
         },
         "node_modules/focus-trap": {
-            "version": "7.6.5",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
-            "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.2.tgz",
+            "integrity": "sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tabbable": "^6.2.0"
+                "tabbable": "^6.5.0"
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -7700,9 +9256,10 @@
             }
         },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7762,9 +9319,10 @@
             }
         },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -8014,12 +9572,6 @@
                 "tslib": "2"
             }
         },
-        "node_modules/glob-to-regexp": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "license": "BSD-2-Clause"
-        },
         "node_modules/globals": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -8154,6 +9706,163 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hast-util-from-parse5": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "devlop": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "property-information": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-location": "^5.0.0",
+                "web-namespaces": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-raw": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "hast-util-to-parse5": "^8.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "parse5": "^7.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0",
+                "web-namespaces": "^2.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-sanitize": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+            "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "unist-util-position": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-jsx-runtime": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+            "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "devlop": "^1.0.0",
+                "estree-util-is-identifier-name": "^3.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "mdast-util-mdx-expression": "^2.0.0",
+                "mdast-util-mdx-jsx": "^3.0.0",
+                "mdast-util-mdxjs-esm": "^2.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "style-to-js": "^1.0.0",
+                "unist-util-position": "^5.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "devlop": "^1.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "web-namespaces": "^2.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-whitespace": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+            "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hastscript": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -8164,12 +9873,24 @@
             }
         },
         "node_modules/highcharts": {
-            "version": "12.4.0",
-            "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.4.0.tgz",
-            "integrity": "sha512-o6UxxfChSUrvrZUbWrAuqL1HO/+exhAUPcZY6nnqLsadZQlnP16d082sg7DnXKZCk1gtfkyfkp6g3qkIZ9miZg==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-13.0.0.tgz",
+            "integrity": "sha512-AoFXei9hSnVXo8X5PmXzSiNXwPMgA+NzyN35uRRy0N1XwbJbRI1laTCaaFci9QB9Wyv9ZFWlgF0xzgivavJpDA==",
             "dev": true,
             "license": "https://www.highcharts.com/license",
-            "peer": true
+            "peer": true,
+            "peerDependencies": {
+                "jspdf": "^4.1.0",
+                "svg2pdf.js": "^2.7.0"
+            },
+            "peerDependenciesMeta": {
+                "jspdf": {
+                    "optional": true
+                },
+                "svg2pdf.js": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
@@ -8177,6 +9898,7 @@
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "react-is": "^16.7.0"
             }
@@ -8186,7 +9908,8 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/hpack.js": {
             "version": "2.1.6",
@@ -8219,6 +9942,28 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/html-url-attributes": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+            "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/html-void-elements": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+            "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/html-webpack-plugin": {
@@ -8315,9 +10060,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+            "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
@@ -8355,6 +10100,19 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "license": "MIT"
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/human-signals": {
             "version": "8.0.1",
@@ -8443,16 +10201,23 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
         },
+        "node_modules/inline-style-parser": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+            "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/inquirer": {
-            "version": "12.10.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.10.0.tgz",
-            "integrity": "sha512-K/epfEnDBZj2Q3NMDcgXWZye3nhSPeoJnOh8lcKWrldw54UEZfS4EmAMsAsmVbl7qKi+vjAsy39Sz4fbgRMewg==",
+            "version": "12.9.6",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.6.tgz",
+            "integrity": "sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==",
             "license": "MIT",
             "dependencies": {
-                "@inquirer/ansi": "^1.0.1",
-                "@inquirer/core": "^10.3.0",
-                "@inquirer/prompts": "^7.9.0",
-                "@inquirer/type": "^3.0.9",
+                "@inquirer/ansi": "^1.0.0",
+                "@inquirer/core": "^10.2.2",
+                "@inquirer/prompts": "^7.8.6",
+                "@inquirer/type": "^3.0.8",
                 "mute-stream": "^2.0.0",
                 "run-async": "^4.0.5",
                 "rxjs": "^7.8.2"
@@ -8492,6 +10257,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/ipaddr.js": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -8499,6 +10274,49 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/is-alphabetical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-alphanumerical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-alphabetical": "^2.0.0",
+                "is-decimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-arguments": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-array-buffer": {
@@ -8644,6 +10462,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-decimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/is-docker": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -8720,6 +10549,17 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-hexadecimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-inside-container": {
@@ -9029,6 +10869,7 @@
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -9042,6 +10883,7 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -9061,15 +10903,33 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
+        "node_modules/jpeg-exif": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+            "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -9084,6 +10944,7 @@
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -9105,6 +10966,13 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -9179,13 +11047,13 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.12.0.tgz",
-            "integrity": "sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+            "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.1.1",
-                "shell-quote": "^1.8.3"
+                "shell-quote": "^1.8.4"
             }
         },
         "node_modules/levn": {
@@ -9369,9 +11237,9 @@
             }
         },
         "node_modules/lint-staged/node_modules/yaml": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -9379,6 +11247,9 @@
             },
             "engines": {
                 "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/listr2": {
@@ -9400,12 +11271,11 @@
             }
         },
         "node_modules/lit": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
-            "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+            "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@lit/reactive-element": "^2.1.0",
                 "lit-element": "^4.2.0",
@@ -9413,21 +11283,21 @@
             }
         },
         "node_modules/lit-element": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.1.tgz",
-            "integrity": "sha512-WGAWRGzirAgyphK2urmYOV72tlvnxw7YfyLDgQ+OZnM9vQQBQnumQ7jUJe6unEzwGU3ahFOjuz1iz1jjrpCPuw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+            "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.4.0",
+                "@lit-labs/ssr-dom-shim": "^1.5.0",
                 "@lit/reactive-element": "^2.1.0",
                 "lit-html": "^3.3.0"
             }
         },
         "node_modules/lit-html": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.1.tgz",
-            "integrity": "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+            "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -9435,11 +11305,16 @@
             }
         },
         "node_modules/loader-runner": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/loader-utils": {
@@ -9471,15 +11346,15 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "dev": true,
             "license": "MIT"
         },
@@ -9577,6 +11452,31 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/loglevel": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+            "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "funding": {
+                "type": "tidelift",
+                "url": "https://tidelift.com/funding/github/npm/loglevel"
+            }
+        },
+        "node_modules/longest-streak": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -9605,28 +11505,45 @@
             "license": "ISC"
         },
         "node_modules/luxon": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
-            "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
         },
+        "node_modules/markdown-table": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/marked": {
-            "version": "15.0.12",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-            "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+            "version": "17.0.6",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+            "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
+        },
+        "node_modules/markerjs2": {
+            "version": "2.32.7",
+            "resolved": "https://registry.npmjs.org/markerjs2/-/markerjs2-2.32.7.tgz",
+            "integrity": "sha512-HeFRZjmc43DOG3lSQp92z49cq2oCYpYn2pX++SkJAW1Dij4xJtRquVRf+cXeSZQWDX3ufns1Ry/bGk+zveP7rA==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE"
         },
         "node_modules/material-colors": {
             "version": "1.2.6",
@@ -9641,6 +11558,304 @@
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mdast-util-from-markdown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+            "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-gfm-autolink-literal": "^2.0.0",
+                "mdast-util-gfm-footnote": "^2.0.0",
+                "mdast-util-gfm-strikethrough": "^2.0.0",
+                "mdast-util-gfm-table": "^2.0.0",
+                "mdast-util-gfm-task-list-item": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-autolink-literal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-find-and-replace": "^3.0.0",
+                "micromark-util-character": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-strikethrough": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+            "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-table": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+            "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "markdown-table": "^3.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-task-list-item": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+            "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-mdx-expression": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+            "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree-jsx": "^1.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-mdx-jsx": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+            "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree-jsx": "^1.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "parse-entities": "^4.0.0",
+                "stringify-entities": "^4.0.0",
+                "unist-util-stringify-position": "^4.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-mdxjs-esm": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+            "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree-jsx": "^1.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-phrasing": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+            "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-hast": {
+            "version": "13.2.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+            "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "trim-lines": "^3.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+            "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "unist-util-visit": "^5.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+            "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/media-typer": {
@@ -9700,6 +11915,597 @@
             "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
             "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/micromark": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+            "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-core-commonmark": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+            "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+            "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "micromark-extension-gfm-autolink-literal": "^2.0.0",
+                "micromark-extension-gfm-footnote": "^2.0.0",
+                "micromark-extension-gfm-strikethrough": "^2.0.0",
+                "micromark-extension-gfm-table": "^2.0.0",
+                "micromark-extension-gfm-tagfilter": "^2.0.0",
+                "micromark-extension-gfm-task-list-item": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-autolink-literal": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+            "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-strikethrough": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+            "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-table": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-tagfilter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+            "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-task-list-item": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+            "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-factory-destination": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+            "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-label": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+            "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-space": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-title": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+            "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-whitespace": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+            "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-character": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-chunked": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+            "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-classify-character": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+            "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-combine-extensions": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+            "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+            "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-string": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+            "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-encode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+            "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+            "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-resolve-all": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+            "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-sanitize-uri": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-subtokenize": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+            "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-symbol": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-types": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+            "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
             "license": "MIT"
         },
         "node_modules/micromatch": {
@@ -9778,12 +12584,12 @@
             "license": "ISC"
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -9798,6 +12604,66 @@
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minimizer-webpack-plugin": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+            "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^4.3.0",
+                "terser": "^5.31.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@minify-html/node": {
+                    "optional": true
+                },
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/css": {
+                    "optional": true
+                },
+                "@swc/html": {
+                    "optional": true
+                },
+                "clean-css": {
+                    "optional": true
+                },
+                "cssnano": {
+                    "optional": true
+                },
+                "csso": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "html-minifier-terser": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
             }
         },
         "node_modules/ms": {
@@ -9828,9 +12694,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.15",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
             "funding": [
                 {
                     "type": "github",
@@ -9914,20 +12780,21 @@
                 }
             }
         },
-        "node_modules/node-forge": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-            "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "engines": {
-                "node": ">= 6.13.0"
-            }
+        "node_modules/node-machine-id": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
+            "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.27",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-            "license": "MIT"
+            "version": "2.0.50",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+            "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -10000,6 +12867,23 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-is": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -10260,6 +13144,33 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parse-entities": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "character-entities-legacy": "^3.0.0",
+                "character-reference-invalid": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "is-alphanumerical": "^2.0.0",
+                "is-decimal": "^2.0.0",
+                "is-hexadecimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/parse-entities/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -10288,6 +13199,32 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/parsedbf": {
@@ -10348,9 +13285,9 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "license": "MIT"
         },
         "node_modules/path-type": {
@@ -10361,15 +13298,49 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pdfmake": {
+            "version": "0.2.23",
+            "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.23.tgz",
+            "integrity": "sha512-A/IksoKb/ikOZH1edSDJ/2zBbqJKDghD4+fXn3rT7quvCJDlsZMs3NmIB3eajLMMFU9Bd3bZPVvlUMXhvFI+bQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@foliojs-fork/linebreak": "^1.1.2",
+                "@foliojs-fork/pdfkit": "^0.15.3",
+                "iconv-lite": "^0.7.1",
+                "xmldoc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/pdfmake/node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -10388,6 +13359,23 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/pkijs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@noble/hashes": "1.4.0",
+                "asn1js": "^3.0.6",
+                "bytestreamjs": "^2.0.1",
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/playwright-chromium": {
@@ -10418,6 +13406,25 @@
                 "node": ">=18"
             }
         },
+        "node_modules/png-js": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+            "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+            "dev": true,
+            "dependencies": {
+                "browserify-zlib": "^0.2.0"
+            }
+        },
+        "node_modules/polylabel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-1.1.0.tgz",
+            "integrity": "sha512-bxaGcA40sL3d6M4hH72Z4NdLqxpXRsCFk8AITYg6x1rn1Ei3izf00UMLklerBZTO49aPA3CYrIwVulx2Bce2pA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "tinyqueue": "^2.0.3"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -10427,9 +13434,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.16",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -10445,9 +13452,8 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -11253,7 +14259,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -11325,17 +14330,25 @@
             "license": "MIT"
         },
         "node_modules/proj4": {
-            "version": "2.19.10",
-            "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.19.10.tgz",
-            "integrity": "sha512-uL6/C6kA8+ncJAEDmUeV8PmNJcTlRLDZZa4/87CzRpb8My4p+Ame4LhC4G3H/77z2icVqcu3nNL9h5buSdnY+g==",
+            "version": "2.20.9",
+            "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
+            "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mgrs": "1.0.0",
-                "wkt-parser": "^1.5.1"
+                "wkt-parser": "^1.5.5"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ahocevar"
+            },
+            "peerDependencies": {
+                "geotiff": "*"
+            },
+            "peerDependenciesMeta": {
+                "geotiff": {
+                    "optional": true
+                }
             }
         },
         "node_modules/prop-types": {
@@ -11352,6 +14365,17 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/property-information": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+            "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -11383,13 +14407,32 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvutils": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+            "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/qs": {
-            "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -11417,14 +14460,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
         },
         "node_modules/range-parser": {
             "version": "1.2.1",
@@ -11485,7 +14520,6 @@
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -11518,7 +14552,6 @@
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -11533,6 +14566,34 @@
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/react-markdown": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+            "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "hast-util-to-jsx-runtime": "^2.0.0",
+                "html-url-attributes": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-rehype": "^11.0.0",
+                "unified": "^11.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            },
+            "peerDependencies": {
+                "@types/react": ">=18",
+                "react": ">=18"
+            }
         },
         "node_modules/react-transition-group": {
             "version": "4.4.5",
@@ -11587,6 +14648,12 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/reflect-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+            "license": "Apache-2.0"
+        },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -11627,6 +14694,37 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/rehype-raw": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+            "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-raw": "^9.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-sanitize": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+            "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-sanitize": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/relateurl": {
             "version": "0.2.7",
             "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -11634,6 +14732,76 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/remark-gfm": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-gfm": "^3.0.0",
+                "micromark-extension-gfm": "^3.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-parse": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+            "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-rehype": {
+            "version": "11.1.2",
+            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+            "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "unified": "^11.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-stringify": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+            "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/remove-accents": {
@@ -11681,9 +14849,9 @@
             "license": "MIT"
         },
         "node_modules/reselect": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+            "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
             "dev": true,
             "license": "MIT"
         },
@@ -11778,6 +14946,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/robust-predicates": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+            "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+            "dev": true,
+            "license": "Unlicense"
+        },
         "node_modules/run-applescript": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -11821,6 +14996,13 @@
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
+        },
+        "node_modules/rw": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+            "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/rxjs": {
             "version": "7.8.2",
@@ -11911,6 +15093,16 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
         },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
+        },
         "node_modules/scheduler": {
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -11941,10 +15133,10 @@
             }
         },
         "node_modules/schema-utils/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "peer": true,
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -11972,6 +15164,13 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
+        "node_modules/seedrandom": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/select-hose": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -11979,16 +15178,16 @@
             "license": "MIT"
         },
         "node_modules/selfsigned": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+            "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
             "license": "MIT",
             "dependencies": {
-                "@types/node-forge": "^1.3.0",
-                "node-forge": "^1"
+                "@peculiar/x509": "^1.14.2",
+                "pkijs": "^3.3.3"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/semver": {
@@ -12048,14 +15247,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dependencies": {
-                "randombytes": "^2.1.0"
             }
         },
         "node_modules/serve-index": {
@@ -12239,9 +15430,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+            "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -12265,13 +15456,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -12283,12 +15475,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -12401,9 +15594,9 @@
             }
         },
         "node_modules/sortablejs": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
-            "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
+            "version": "1.15.7",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+            "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
             "dev": true,
             "license": "MIT"
         },
@@ -12432,6 +15625,17 @@
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/space-separated-tokens": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+            "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/spdy": {
@@ -12653,6 +15857,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/stringify-entities": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+            "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "character-entities-html4": "^2.0.0",
+                "character-entities-legacy": "^3.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -12697,6 +15916,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/stubborn-fs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+            "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "stubborn-utils": "^1.0.1"
+            }
+        },
+        "node_modules/stubborn-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+            "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/style-loader": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
@@ -12711,6 +15947,26 @@
             },
             "peerDependencies": {
                 "webpack": "^5.27.0"
+            }
+        },
+        "node_modules/style-to-js": {
+            "version": "1.1.21",
+            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+            "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "style-to-object": "1.0.14"
+            }
+        },
+        "node_modules/style-to-object": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+            "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inline-style-parser": "0.2.7"
             }
         },
         "node_modules/stylis": {
@@ -12742,17 +15998,24 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/svg-arc-to-cubic-bezier": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+            "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/tabbable": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+            "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/tapable": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -12777,39 +16040,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/terser-webpack-plugin": {
-            "version": "5.3.14",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-            "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jest-worker": "^27.4.5",
-                "schema-utils": "^4.3.0",
-                "serialize-javascript": "^6.0.2",
-                "terser": "^5.31.1"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "uglify-js": {
-                    "optional": true
-                }
             }
         },
         "node_modules/terser/node_modules/commander": {
@@ -12856,6 +16086,13 @@
                 "node": ">=18.12.0"
             }
         },
+        "node_modules/tiny-inflate": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinycolor2": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -12895,16 +16132,23 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "peer": true,
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
+        },
+        "node_modules/tinyqueue": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+            "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -12947,6 +16191,28 @@
             },
             "peerDependencies": {
                 "tslib": "2"
+            }
+        },
+        "node_modules/trim-lines": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+            "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/trough": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+            "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/ts-api-utils": {
@@ -13072,8 +16338,25 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
+        },
+        "node_modules/tsyringe": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+            "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/tsyringe/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -13187,7 +16470,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
             "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -13242,6 +16524,35 @@
             "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
             "license": "MIT"
         },
+        "node_modules/unicode-properties": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+            "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "unicode-trie": "^2.0.0"
+            }
+        },
+        "node_modules/unicode-trie": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+            "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^0.2.5",
+                "tiny-inflate": "^1.0.0"
+            }
+        },
+        "node_modules/unicode-trie/node_modules/pako": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/unicorn-magic": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -13253,6 +16564,99 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-is": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+            "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-position": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+            "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-stringify-position": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+            "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit-parents": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+            "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/universalify": {
@@ -13306,9 +16710,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-            "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -13437,13 +16841,57 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/watchpack": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-            "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+        "node_modules/vfile": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+            "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "glob-to-regexp": "^0.4.1",
+                "@types/unist": "^3.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/vfile-location": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+            "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/vfile-message": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+            "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/watchpack": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+            "license": "MIT",
+            "dependencies": {
                 "graceful-fs": "^4.1.2"
             },
             "engines": {
@@ -13459,6 +16907,17 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
+        "node_modules/web-namespaces": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+            "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -13467,37 +16926,33 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
-            "version": "5.102.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
-            "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
+            "version": "5.108.4",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
+            "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.15.0",
+                "acorn": "^8.16.0",
                 "acorn-import-phases": "^1.0.3",
-                "browserslist": "^4.26.3",
+                "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.3",
-                "es-module-lexer": "^1.2.1",
+                "enhanced-resolve": "^5.22.2",
+                "es-module-lexer": "^2.1.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
-                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
-                "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
-                "mime-types": "^2.1.27",
+                "loader-runner": "^4.3.2",
+                "mime-db": "^1.54.0",
+                "minimizer-webpack-plugin": "^5.6.1",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
-                "terser-webpack-plugin": "^5.3.11",
-                "watchpack": "^2.4.4",
-                "webpack-sources": "^3.3.3"
+                "watchpack": "^2.5.2",
+                "webpack-sources": "^3.5.0"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -13584,14 +17039,14 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-            "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+            "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
             "license": "MIT",
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
-                "@types/express": "^4.17.21",
+                "@types/express": "^4.17.25",
                 "@types/express-serve-static-core": "^4.17.21",
                 "@types/serve-index": "^1.9.4",
                 "@types/serve-static": "^1.15.5",
@@ -13601,17 +17056,17 @@
                 "bonjour-service": "^1.2.1",
                 "chokidar": "^3.6.0",
                 "colorette": "^2.0.10",
-                "compression": "^1.7.4",
+                "compression": "^1.8.1",
                 "connect-history-api-fallback": "^2.0.0",
-                "express": "^4.21.2",
+                "express": "^4.22.1",
                 "graceful-fs": "^4.2.6",
                 "http-proxy-middleware": "^2.0.9",
                 "ipaddr.js": "^2.1.0",
-                "launch-editor": "^2.6.1",
+                "launch-editor": "^2.14.1",
                 "open": "^10.0.3",
                 "p-retry": "^6.2.0",
                 "schema-utils": "^4.2.0",
-                "selfsigned": "^2.4.1",
+                "selfsigned": "^5.5.0",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
@@ -13655,9 +17110,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-            "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+            "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
@@ -13681,6 +17136,15 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "engines": {
                 "node": ">=4.0"
+            }
+        },
+        "node_modules/webpack/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/websocket-driver": {
@@ -13716,6 +17180,13 @@
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
             }
+        },
+        "node_modules/when-exit": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+            "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -13824,11 +17295,14 @@
             "license": "MIT"
         },
         "node_modules/wkt-parser": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.2.tgz",
-            "integrity": "sha512-1ZUiV1FTwSiSrgWzV9KXJuOF2BVW91KY/mau04BhnmgOdroRQea7Q0s5TVqwGLm0D2tZwObd/tBYXW49sSxp3Q==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.5.tgz",
+            "integrity": "sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ahocevar"
+            }
         },
         "node_modules/word-wrap": {
             "version": "1.2.5",
@@ -13883,9 +17357,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -13931,6 +17405,19 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/xmldoc": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+            "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sax": "^1.4.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/xss": {
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
@@ -13965,19 +17452,20 @@
             }
         },
         "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
         },
         "node_modules/yargs": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "version": "16.2.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+            "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14069,6 +17557,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zwitch": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+            "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     },
     "devDependencies": {
         "@types/node": "~22.13.14",
-        "@vertigis/web": "^5.38.0",
+        "@vertigis/web": "^5.42.0",
         "conventional-changelog-conventionalcommits": "7.0.2",
         "cross-env": "7.0.3",
         "eslint": "^9.37.0",
@@ -57,5 +57,12 @@
     },
     "lint-staged": {
         "*.{js,json,ts,tsx,md,xml}": "prettier --write"
+    },
+    "allowScripts": {
+        "@mui/x-telemetry": false,
+        "@vaadin/vaadin-usage-statistics": false,
+        "playwright-chromium": false,
+        "simple-git-hooks": false,
+        "unrs-resolver": false
     }
 }

--- a/template/src/components/PointsOfInterest/PointsOfInterestModel.ts
+++ b/template/src/components/PointsOfInterest/PointsOfInterestModel.ts
@@ -1,5 +1,4 @@
 import Collection from "@arcgis/core/core/Collection";
-import { ResourceHandle } from "@arcgis/core/core/Handles";
 import type Point from "@arcgis/core/geometry/Point";
 import type { ChangeEvent } from "@vertigis/arcgis-extensions/support/esri";
 import type { LocationMarkerEvent } from "@vertigis/viewer-spec/messaging/registry/location-marker";
@@ -36,7 +35,6 @@ export default class PointsOfInterestModel extends ComponentModelBase<PointsOfIn
     // changes.
     readonly pointsOfInterest = new Collection<PointOfInterestModel>();
     private _nextId = 1;
-    private readonly _handles: ResourceHandle[] = [];
 
     /**
      * Creates a new point of interest at the specified location.
@@ -81,9 +79,11 @@ export default class PointsOfInterestModel extends ComponentModelBase<PointsOfIn
         // override a method.
         await super._onInitialize();
 
-        // Registration handles for event handlers should be saved and cleaned
-        // up when no longer needed.
-        this._handles.push(
+        // Everything that extends `ComponentModelBase` will have a special
+        // collection attached called `_handles`. You can add the results of
+        // any event subscriptions here and they will be cleaned up
+        // automatically.
+        this._handles.add(
             this.messages.events.locationMarker.updated.subscribe(this._onMarkerUpdated),
             this.pointsOfInterest.on("change", this._onPointOfInterestsChange)
         );
@@ -94,7 +94,7 @@ export default class PointsOfInterestModel extends ComponentModelBase<PointsOfIn
         await super._onDestroy();
 
         // Clean up event handlers.
-        this._handles.forEach(h => h.remove());
+        this._handles.removeAll();
     }
 
     private readonly _onMarkerUpdated = (e: LocationMarkerEvent): void => {

--- a/template/src/components/PointsOfInterest/PointsOfInterestModel.ts
+++ b/template/src/components/PointsOfInterest/PointsOfInterestModel.ts
@@ -89,14 +89,6 @@ export default class PointsOfInterestModel extends ComponentModelBase<PointsOfIn
         );
     }
 
-    protected override async _onDestroy(): Promise<void> {
-        // Always invoke the super implementation.
-        await super._onDestroy();
-
-        // Clean up event handlers.
-        this._handles.removeAll();
-    }
-
     private readonly _onMarkerUpdated = (e: LocationMarkerEvent): void => {
         const matchingPoi = this.pointsOfInterest.find(poi => poi.id === e.id);
         if (matchingPoi) {


### PR DESCRIPTION
Fixes an issue preventing the compilation of the default template with Web 42. Note that this fix means previous versions of Web will no longer be able to compile the updated template.

Note also that there is an audit issue that will need to be addressed with an `sdk-library` update as WebpackDevServer needs to be upgraded to version 6. Once this update is made it will automatically apply to this repo as well as long as the standard `npx ...` method of running `create` is used.